### PR TITLE
Issue/10/tomo bins

### DIFF
--- a/src/rail/estimation/algos/naiveClassifierSRD.py
+++ b/src/rail/estimation/algos/naiveClassifierSRD.py
@@ -1,0 +1,54 @@
+"""
+A classifier that uses pz point estimate to assign
+tomographic bins according to SRD
+"""
+
+import numpy as np
+from ceci.config import StageParameter as Param
+from rail.estimation.tomographer import PZTomographer
+from rail.core.data import TanbleHandle
+
+class naiveClassifierSRD(PZTomographer):
+    """Classifier that simply assign tomographic 
+    bins based on point estimate according to SRD"""
+    
+    name = 'naiveClassifierSRD'
+    config_options = PZSummarizer.config_options.copy()
+    config_options.update(
+        binning_option=Param(str, 'lensY1', msg="Which binning in SRD to use (lensY1, lensY10, source)",
+        point_estimate=Param(str, 'zmode', msg="Which point estimate to use"))
+    outputs = [('output', TableHandle)]
+    
+    def __init__(self, args, comm=None):
+        PZTomographer.__init__(self, args, comm=comm)
+        
+    def run(self):
+        test_data = self.get_data('input')
+        npdf = test_data.npdf
+        zb = test_data.ancil[self.config.point_estimate]
+        
+        # binning option
+        if self.config.binning_option == 'lensY1':
+            # 5 bins between 0.2<z<1.2
+            bin_index = np.digitize(zb, np.linspace(0.2,1.2,6))
+            # assign -99 to objects not in any bin:
+            bin_index[bin_index==0]=-99
+            bin_index[bin_index==6]=-99
+    
+        elif self.config.binning_option == 'lensY10':
+            # 10 bins between 0.2<z<1.2
+            bin_index = np.digitize(pz, np.linspace(0.2,1.2,11))
+            bin_index[bin_index==0]=-99
+            bin_index[bin_index==11]=-99
+
+        elif self.config.binning_option == 'source':
+            # 5 bins with equal number density
+            sortind = np.argsort(zb)
+            N_perbin = int(len(bz)/nbins)
+            bin_index = np.zeros(len(zb))
+            for ii in range(nbins):
+                useind = sortind[ii*N_perbin:(ii+1)*N_perbin]
+                bin_index[useind] = int(ii+1)
+
+        tomo = {"tomo": bin_index}
+        self.add_data('output', tomo)

--- a/src/rail/estimation/algos/randomForestClassifier.py
+++ b/src/rail/estimation/algos/randomForestClassifier.py
@@ -1,0 +1,118 @@
+"""
+An example classifier that uses catalogue information to
+classify objects into tomoragphic bins using random forest.
+This is the base method in TXPipe, adapted from TXpipe/binning/random_forest.py
+Note: extra dependence on sklearn and input training file.
+"""
+
+import numpy as np
+from ceci.config import StageParameter as Param
+from rail.estimation.tomographer import PZTomographer
+from rail.core.data import TanbleHandle
+from sklearn.ensemble import RandomForestClassifier
+import tables_io
+
+class randomForestClassifier(CatTomographer):
+    """Classifier that assigns tomographic 
+    bins based on random forest method"""
+    
+    name = 'randomForestClassifier'
+    config_options = CatSummarizer.config_options.copy()
+    config_options.update(
+        bands=Param(tuple, ["g","r","z"], msg="Which bands to use for classification"),
+        band_names=param(dict, {}, msg="Band column names"),
+        z_name=param(str, "sz", msg="Redshift column names"),
+        traning_file=Param(str, '', msg="Training file to use"),
+        bin_edges=Param(tuple, [0,0.5,1.0], msg="Binning for training data"),
+        random_seed=Param(int, msg="random seed"),)
+    outputs = [('output', TableHandle)]
+    
+    def __init__(self, args, comm=None):
+        PZTomographer.__init__(self, args, comm=comm)
+            
+    def build_tomographic_classifier(self):
+        # Load the training data
+        training_data_table = tables_io.read(self.config.training_file)
+
+        # Pull out the appropriate columns and combinations of the data
+        print(f"Using these bands to train the tomography selector: {self.config.bands}")
+        
+        # Generate the training data that we will use
+        # We record both the name of the column and the data itself
+        features = []
+        training_data = []
+        for b1 in self.config.bands[:]:
+            b1_cat=self.config.band_names[b1]
+            # First we use the magnitudes themselves
+            features.append(b1)
+            training_data.append(training_data_table[b1_cat])
+            # We also use the colours as training data, even the redundant ones
+            for b2 in self.config.bands[:]:
+                b2_cat=self.config.band_names[b2]
+                if b1 < b2:
+                    features.append(f"{b1}-{b2}")
+                    training_data.append(training_data_table[b1_cat] - training_data_table[b2_cat])
+        training_data = np.array(training_data).T
+
+        print("Training data for bin classifier has shape ", training_data.shape)
+
+        # Now put the training data into redshift bins
+        # We use -1 to indicate that we are outside the desired ranges
+        z = training_data_table[self.config.z_name]
+        training_bin = np.repeat(-1, len(z))
+        print("Using these bin edges:", self.config.bin_edges)
+        for i, zmin in enumerate(self.config.bin_edges[:-1]):
+            zmax = self.config.bin_edges[i + 1]
+            training_bin[(z > zmin) & (z < zmax)] = i
+            ntrain_bin = ((z > zmin) & (z < zmax)).sum()
+            print(f"Training set: {ntrain_bin} objects in tomographic bin {i}")
+
+        # Can be replaced with any classifier
+        classifier = RandomForestClassifier(
+            max_depth=10,
+            max_features=None,
+            n_estimators=20,
+            random_state=self.config.random_seed,
+        )
+        classifier.fit(training_data, training_bin)
+
+        return classifier, features
+
+    
+    def apply_classifier(self, test_data, classifier, features):
+        """Apply the classifier to the measured magnitudes"""
+
+        data = []
+        for f in features:
+            # may be a single band
+            if len(f) == 1:
+                f_cat=self.config.band_names[f]
+                col = test_data[f_cat]
+            # or a colour
+            else:
+                b1, b2 = f.split("-")
+                b1_cat=self.config.band_names[b1]
+                b2_cat=self.config.band_names[b2]
+                col = (test_data[b1_cat] - test_data[b2_cat])
+            if np.all(~np.isfinite(col)):
+                # entire column is NaN.  Hopefully this will get deselected elsewhere
+                col[:] = 30.0
+            else:
+                ok = np.isfinite(col)
+                col[~ok] = col[ok].max()
+            data.append(col)
+            data = np.array(data).T
+
+        # Run the random forest on this data chunk
+        bin_index = classifier.predict(data)
+        return bin_index
+        
+        
+    def run(self):
+        """Run random forest classifier"""
+        
+        test_data = self.get_data('input')
+        classifier, features = build_tomographic_classifier()
+        bin_index=apply_classifier(test_data, classifier, features)
+        tomo = {"tomo": bin_index}
+        self.add_data('output', tomo)

--- a/src/rail/estimation/algos/randomForestClassifier.py
+++ b/src/rail/estimation/algos/randomForestClassifier.py
@@ -7,7 +7,7 @@ Note: extra dependence on sklearn and input training file.
 
 import numpy as np
 from ceci.config import StageParameter as Param
-from rail.estimation.tomographer import PZTomographer
+from rail.estimation.tomographer import CatTomographer
 from rail.core.data import TanbleHandle
 from sklearn.ensemble import RandomForestClassifier
 import tables_io

--- a/src/rail/estimation/algos/randomForestClassifier.py
+++ b/src/rail/estimation/algos/randomForestClassifier.py
@@ -19,8 +19,8 @@ class randomForestClassifier(CatTomographer):
     name = 'randomForestClassifier'
     config_options = CatSummarizer.config_options.copy()
     config_options.update(
-        bands=Param(tuple, ["g","r","z"], msg="Which bands to use for classification"),
-        band_names=param(dict, {}, msg="Band column names"),
+        bands=Param(tuple, ["r","i","z"], msg="Which bands to use for classification"),
+        band_names=param(dict, {"r": "mag_r", "i": "mag_i", "z":"mag_z"}, msg="Band column names"),
         z_name=param(str, "sz", msg="Redshift column names"),
         traning_file=Param(str, '', msg="Training file to use"),
         bin_edges=Param(tuple, [0,0.5,1.0], msg="Binning for training data"),

--- a/src/rail/estimation/tomographer.py
+++ b/src/rail/estimation/tomographer.py
@@ -1,0 +1,103 @@
+"""
+Abstract base classes defining redshift estimations Tomographers
+"""
+from rail.core.data import QPHandle, TableHandle, ModelHandle
+from rail.core.stage import RailStage
+
+class CatTomographer(RailStage):
+    """The base class for assigning tomographic bins to catalogue-like table.
+
+    Tomographer use a generic "model", the details of which depends on the sub-class.
+
+    CatTomographer take as "input" a catalogue-like table, assign each object into
+    a tomographic bin, and provide as "output" a tabular data which can be appended 
+    to the catalogue.
+    """
+    
+    name='CatTomograhper'
+    config_options = RailStage.config_options.copy()
+    config_options.update(chunk_size=10000)
+    inputs = [('input', TableHandle)]
+    outputs = [('output', TableHandle)]
+    
+    def __init__(self, args, comm=None):
+        """Initialize Summarizer"""
+        RailStage.__init__(self, args, comm=comm)
+        
+    def tomography(self, input_data):
+        """The main run method for the tomographer, should be implemented
+        in the specific subclass.
+
+        This will attach the input_data to this `CatTomograhper`
+        (for introspection and provenance tracking).
+
+        Then it will call the run() and finalize() methods, which need to
+        be implemented by the sub-classes.
+
+        The run() method will need to register the data that it creates to this Tomographer
+        by using `self.add_data('output', output_data)`.
+
+        Finally, this will return a TableHandle providing access to that output data.
+
+        Parameters
+        ----------
+        input_data : `dict`
+            A dictionary of all input data
+
+        Returns
+        -------
+        output: `dict`
+            Tomographic assignment for each galaxy. No assignment=-99.
+        """
+        self.set_data('input', input_data)
+        self.run()
+        self.finalize()
+        return self.get_handle('output')
+    
+
+class PZTomographer(RailStage):
+    """The base class for assigning tomographic bins to per-galaxy PZ estimates
+
+    PZTomographer take as "input" a `qp.Ensemble` with per-galaxy PDFs, and
+    provide as "output" a tabular data which can be appended to the catalogue.
+    """
+    
+    name='PZTomograhper'
+    config_options = RailStage.config_options.copy()
+    config_options.update(chunk_size=10000)
+    inputs = [('input', QPHandle)]
+    outputs = [('output', TableHandle)]
+    
+    def __init__(self, args, comm=None):
+        """Initialize Summarizer"""
+        RailStage.__init__(self, args, comm=comm)
+        
+    def tomography(self, input_data):
+        """The main run method for the tomographer, should be implemented
+        in the specific subclass.
+
+        This will attach the input_data to this `PZTomograhper`
+        (for introspection and provenance tracking).
+
+        Then it will call the run() and finalize() methods, which need to
+        be implemented by the sub-classes.
+
+        The run() method will need to register the data that it creates to this Tomographer
+        by using `self.add_data('output', output_data)`.
+
+        Finally, this will return a TableHandle providing access to that output data.
+
+        Parameters
+        ----------
+        input_data : `qp.Ensemble`
+            Per-galaxy p(z), and any ancilary data associated with it
+
+        Returns
+        -------
+        output: `dict`
+            Tomographic assignment for each galaxy. No assignment=-99.
+        """
+        self.set_data('input', input_data)
+        self.run()
+        self.finalize()
+        return self.get_handle('output')


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
- [x] My PR includes a link to the issue that I am addressing
Resolves #10 


## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->

In this PR I have added a `tomographer` module under `src/rail/estimation`. It contains two generic tomographer classes:

- `PZTomographer`, which takes per-galaxy n(z) from a `qp.Ensemble` object and output a tabular object with tomographic binning;
- `CatTomographer`, which takes catalogue-like data and output a tabular object with tomographic binning;
The second type will be compatible with the classifiers in tomo-challenge, where features in the catalogue are used to assign tomographic bins.

For each of these types, I've added an example classifier in `algos/`. `naiveClassifierSRD` is a PZtomographer that uses simple point estimate SRD binning; `randomForestClassifier` is a CatTomographer which is adapted from TXPipe.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### Bug Fix Checklist
- [ ] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

### Documentation Change Checklist
- [ ] Any updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)

### Build/CI Change Checklist
- [ ] If required or optional dependencies have changed (including version numbers), I have updated the README to reflect this
- [ ] If this is a new CI setup, I have added the associated badge to the README

<!-- ### Version Change Checklist [For Future Use] -->

### Other Change Checklist
- [ ] Any new or updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html).
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover any changes
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
