### PR TITLE
get data as a cli script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ dask-worker-space/
 
 # tmp directory
 tmp/
+
+# macOS
+.DS_Store

--- a/src/rail/cli/commands.py
+++ b/src/rail/cli/commands.py
@@ -54,3 +54,11 @@ def info(**kwargs):
     """Print information about the rail ecosystem"""
     scripts.info(**kwargs)
     return 0
+
+
+@cli.command()
+@options.verbose_download()
+def get_data(verbose, **kwargs):
+    """Downloads data from NERSC (if not already found)"""
+    scripts.get_data(verbose, **kwargs)
+    return 0

--- a/src/rail/cli/options.py
+++ b/src/rail/cli/options.py
@@ -18,6 +18,7 @@ __all__ = [
     "print_stages",
     "package_file",
     "inputs",
+    "verbose_download"
 ]
 
 

--- a/src/rail/cli/options.py
+++ b/src/rail/cli/options.py
@@ -131,10 +131,6 @@ print_stages = PartialOption(
     is_flag=True,
 )
 
-
-
-
-
 package_file = PartialOption(
     "--package-file",
     type=click.Path(),
@@ -147,3 +143,9 @@ inputs = PartialArgument(
     nargs=-1
 )
 
+verbose_download = PartialOption(
+    "-v",
+    "--verbose",
+    help="Verbose output when downloading",
+    is_flag=True
+)

--- a/src/rail/cli/scripts.py
+++ b/src/rail/cli/scripts.py
@@ -120,5 +120,17 @@ def info(**kwargs):
         print("\n\n")
     
 
-
+def get_data(verbose, **kwargs):
     
+    data_files = [
+        {
+            "local_path": "src/rail/examples_data/goldenspike_data/data/base_catalog.pq",
+            "remote_path": "https://portal.nersc.gov/cfs/lsst/PZ/base_catalog.pq"
+        }
+    ]
+
+    for data_file in data_files:
+        if verbose:
+            print(f'Check file: {data_file["local_path"]}')
+        if not os.path.exists(data_file["local_path"]):
+            os.system(f'curl -o {data_file["local_path"]} {data_file["remote_path"]} --create-dirs')

--- a/src/rail/cli/scripts.py
+++ b/src/rail/cli/scripts.py
@@ -120,8 +120,8 @@ def info(**kwargs):
         print("\n\n")
     
 
-def get_data(verbose, **kwargs):
-    
+def get_data(verbose, **kwargs):  # pragma: no cover
+
     data_files = [
         {
             "local_path": "src/rail/examples_data/goldenspike_data/data/base_catalog.pq",


### PR DESCRIPTION
## Change Description
Translated from draft PR #43 (rail).

Now implemented as cli script.

Required for rail_attic's https://github.com/LSSTDESC/rail_attic/pull/372 (fixing goldenspike pipeline); addresses rail_attic [#356](https://github.com/LSSTDESC/rail/pull/43#356) (moving data) and rail [#26](https://github.com/LSSTDESC/rail/pull/43#26) (moving demo files).



## Solution Description

A script to check for existence of data files and curl what is missing.

Chose not to add testing, as this could result in overuse of NERSC data storage (and testing presence of data seems to require first wiping data, which...)

Future steps could involve additional options for the command that allow the user to specify which data; perhaps utilizing the [prompting](https://click.palletsprojects.com/en/8.1.x/options/#prompting) feature in click to interactively walk the user through each file and pick skip or download.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have updated the tutorial to highlight my new feature (if appropriate)
- [No - see note above] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)