### PR TITLE
naming consistency/clarity within src/rail/estimation

### DIFF
--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -9,11 +9,11 @@ from rail.core.data import QPHandle
 import qp
 
 
-class NaiveStack(PZSummarizer):
+class NaiveStackSummarizer(PZSummarizer):
     """Summarizer which simply histograms a point estimate
     """
 
-    name = 'NaiveStack'
+    name = 'NaiveStackSummarizer'
     config_options = PZSummarizer.config_options.copy()
     config_options.update(zmin=Param(float, 0.0, msg="The minimum redshift of the z grid"),
                           zmax=Param(float, 3.0, msg="The maximum redshift of the z grid"),

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -9,11 +9,11 @@ from rail.core.data import QPHandle
 import qp
 
 
-class PointEstimateHist(PZSummarizer):
+class PointEstHistSummarizer(PZSummarizer):
     """Summarizer which simply histograms a point estimate
     """
 
-    name = 'PointEstimateHist'
+    name = 'PointEstHistSummarizer'
     config_options = PZSummarizer.config_options.copy()
     config_options.update(zmin=Param(float, 0.0, msg="The minimum redshift of the z grid"),
                           zmax=Param(float, 3.0, msg="The maximum redshift of the z grid"),

--- a/src/rail/estimation/algos/random_gauss.py
+++ b/src/rail/estimation/algos/random_gauss.py
@@ -12,11 +12,11 @@ from rail.core.data import TableHandle
 import qp
 
 
-class RandomPZ(CatEstimator):
+class RandomGaussEstimator(CatEstimator):
     """Random CatEstimator
     """
 
-    name = 'RandomPZ'
+    name = 'RandomGaussEstimator'
     inputs = [('input', TableHandle)]
     config_options = CatEstimator.config_options.copy()
     config_options.update(rand_width=Param(float, 0.025, "ad hock width of PDF"),

--- a/src/rail/estimation/algos/train_z.py
+++ b/src/rail/estimation/algos/train_z.py
@@ -23,11 +23,11 @@ class trainZmodel:
         self.zmode = zmode
 
 
-class Inform_trainZ(CatInformer):
+class TrainZInformer(CatInformer):
     """Train an Estimator which returns a global PDF for all galaxies
     """
 
-    name = 'Inform_trainZ'
+    name = 'TrainZInformer'
     config_options = CatInformer.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,
@@ -56,11 +56,11 @@ class Inform_trainZ(CatInformer):
         self.add_data('model', self.model)
 
 
-class TrainZ(CatEstimator):
+class TrainZEstimator(CatEstimator):
     """CatEstimator which returns a global PDF for all galaxies
     """
 
-    name = 'TrainZ'
+    name = 'TrainZEstimator'
     config_options = CatEstimator.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,

--- a/src/rail/estimation/algos/var_inf.py
+++ b/src/rail/estimation/algos/var_inf.py
@@ -13,7 +13,7 @@ from scipy.stats import dirichlet
 TEENY = 1.e-15
 
 
-class VarInferenceStack(PZSummarizer):
+class VarInfStackSummarizer(PZSummarizer):
     """Variational inference summarizer based on notebook created by Markus Rau
     The summzarizer is appropriate for the likelihoods returned by
     template-based codes, for which the NaiveSummarizer are not appropriate.
@@ -32,7 +32,7 @@ class VarInferenceStack(PZSummarizer):
       number of samples used in dirichlet to determind error bar
     """
 
-    name = 'VarInferenceStack'
+    name = 'VarInfStackSummarizer'
     config_options = PZSummarizer.config_options.copy()
     config_options.update(zmin=Param(float, 0.0, msg="The minimum redshift of the z grid"),
                           zmax=Param(float, 3.0, msg="The maximum redshift of the z grid"),

--- a/src/rail/estimation/summarizer.py
+++ b/src/rail/estimation/summarizer.py
@@ -106,7 +106,7 @@ class PZSummarizer(RailStage):
 
 class SZPZSummarizer(RailStage):  #pragma: no cover
     """The base class for classes that use two sets of data: a photometry sample with
-    spec-z values, and a photometry sample with unknown redshifts, e.g. simpleSOM and
+    spec-z values, and a photometry sample with unknown redshifts, e.g. minisom_som and
     outputs a QP Ensemble with bootstrap realization of the N(z) distribution
     """
     name = 'SZPZtoNZSummarizer'

--- a/src/rail/examples_data/goldenspike_data/goldenspike.yml
+++ b/src/rail/examples_data/goldenspike_data/goldenspike.yml
@@ -42,13 +42,13 @@ stages:
 - classname: QuantityCut
   name: quantity_cut
   nprocess: 1
-- classname: Inform_trainZ
+- classname: TrainZInformer
   name: inform_trainZ
   nprocess: 1
 - classname: Estimator
   name: estimate_bpz
   nprocess: 1
-- classname: TrainZ
+- classname: TrainZEstimator
   name: estimate_trainZ
   nprocess: 1
 - classname: RandomGaussEstimator

--- a/src/rail/examples_data/goldenspike_data/goldenspike.yml
+++ b/src/rail/examples_data/goldenspike_data/goldenspike.yml
@@ -51,7 +51,7 @@ stages:
 - classname: TrainZ
   name: estimate_trainZ
   nprocess: 1
-- classname: RandomPZ
+- classname: RandomGaussEstimator
   name: estimate_randomZ
   nprocess: 1
 - classname: PointEstHistSummarizer

--- a/src/rail/examples_data/goldenspike_data/goldenspike.yml
+++ b/src/rail/examples_data/goldenspike_data/goldenspike.yml
@@ -57,6 +57,6 @@ stages:
 - classname: PointEstimateHist
   name: point_estimate_test
   nprocess: 1
-- classname: NaiveStack
+- classname: NaiveStackSummarizer
   name: naive_stack_test
   nprocess: 1

--- a/src/rail/examples_data/goldenspike_data/goldenspike.yml
+++ b/src/rail/examples_data/goldenspike_data/goldenspike.yml
@@ -54,7 +54,7 @@ stages:
 - classname: RandomPZ
   name: estimate_randomZ
   nprocess: 1
-- classname: PointEstimateHist
+- classname: PointEstHistSummarizer
   name: point_estimate_test
   nprocess: 1
 - classname: NaiveStackSummarizer

--- a/src/rail/stages/__init__.py
+++ b/src/rail/stages/__init__.py
@@ -6,7 +6,7 @@ from rail.estimation.estimator import *
 from rail.estimation.summarizer import *
 from rail.estimation.algos.naive_stack import *
 from rail.estimation.algos.randomPZ import *
-from rail.estimation.algos.pointEstimateHist import *
+from rail.estimation.algos.point_est_hist import *
 from rail.estimation.algos.trainZ import *
 from rail.estimation.algos.varInference import *
 

--- a/src/rail/stages/__init__.py
+++ b/src/rail/stages/__init__.py
@@ -7,7 +7,7 @@ from rail.estimation.summarizer import *
 from rail.estimation.algos.naive_stack import *
 from rail.estimation.algos.random_gauss import *
 from rail.estimation.algos.point_est_hist import *
-from rail.estimation.algos.trainZ import *
+from rail.estimation.algos.train_z import *
 from rail.estimation.algos.varInference import *
 
 from rail.creation.degrader import *

--- a/src/rail/stages/__init__.py
+++ b/src/rail/stages/__init__.py
@@ -5,7 +5,7 @@ from rail.core import RailEnv
 from rail.estimation.estimator import *
 from rail.estimation.summarizer import *
 from rail.estimation.algos.naive_stack import *
-from rail.estimation.algos.randomPZ import *
+from rail.estimation.algos.random_gauss import *
 from rail.estimation.algos.point_est_hist import *
 from rail.estimation.algos.trainZ import *
 from rail.estimation.algos.varInference import *

--- a/src/rail/stages/__init__.py
+++ b/src/rail/stages/__init__.py
@@ -8,7 +8,7 @@ from rail.estimation.algos.naive_stack import *
 from rail.estimation.algos.random_gauss import *
 from rail.estimation.algos.point_est_hist import *
 from rail.estimation.algos.train_z import *
-from rail.estimation.algos.varInference import *
+from rail.estimation.algos.var_inf import *
 
 from rail.creation.degrader import *
 #from rail.creation.degradation.spectroscopic_degraders import *

--- a/src/rail/stages/__init__.py
+++ b/src/rail/stages/__init__.py
@@ -4,7 +4,7 @@ from rail.core import RailEnv
 
 from rail.estimation.estimator import *
 from rail.estimation.summarizer import *
-from rail.estimation.algos.naiveStack import *
+from rail.estimation.algos.naive_stack import *
 from rail.estimation.algos.randomPZ import *
 from rail.estimation.algos.pointEstimateHist import *
 from rail.estimation.algos.trainZ import *

--- a/tests/estimation/test_algos.py
+++ b/tests/estimation/test_algos.py
@@ -4,7 +4,7 @@ import scipy.special
 
 from rail.core.algo_utils import one_algo
 from rail.core.stage import RailStage
-from rail.estimation.algos import randomPZ, trainZ
+from rail.estimation.algos import random_gauss, trainZ
 
 sci_ver_str = scipy.__version__.split(".")
 
@@ -25,7 +25,7 @@ def test_random_pz():
     }
     # zb_expected = np.array([1.359, 0.013, 0.944, 1.831, 2.982, 1.565, 0.308, 0.157, 0.986, 1.679])
     train_algo = None
-    pz_algo = randomPZ.RandomPZ
+    pz_algo = random_gauss.RandomGaussEstimator
     results, rerun_results, rerun3_results = one_algo(
         "RandomPZ", train_algo, pz_algo, train_config_dict, estim_config_dict
     )

--- a/tests/estimation/test_algos.py
+++ b/tests/estimation/test_algos.py
@@ -4,7 +4,7 @@ import scipy.special
 
 from rail.core.algo_utils import one_algo
 from rail.core.stage import RailStage
-from rail.estimation.algos import random_gauss, trainZ
+from rail.estimation.algos import random_gauss, train_z
 
 sci_ver_str = scipy.__version__.split(".")
 
@@ -44,8 +44,8 @@ def test_train_pz():
     zb_expected = np.repeat(0.1445183, 10)
     pdf_expected = np.zeros(shape=(301,))
     pdf_expected[10:16] = [7, 23, 8, 23, 26, 13]
-    train_algo = trainZ.Inform_trainZ
-    pz_algo = trainZ.TrainZ
+    train_algo = train_z.TrainZInformer
+    pz_algo = train_z.TrainZEstimator
     results, rerun_results, rerun3_results = one_algo(
         "TrainZ", train_algo, pz_algo, train_config_dict, estim_config_dict
     )

--- a/tests/estimation/test_summarizers.py
+++ b/tests/estimation/test_summarizers.py
@@ -7,7 +7,7 @@ import pytest
 from rail.core.data import QPHandle
 from rail.core.stage import RailStage
 from rail.core.utils import RAILDIR
-from rail.estimation.algos import naiveStack, pointEstimateHist, varInference
+from rail.estimation.algos import naive_stack, pointEstimateHist, varInference
 
 testdata = os.path.join(RAILDIR, "rail/examples_data/testdata/output_BPZ_lite.fits")
 DS = RailStage.data_store
@@ -29,7 +29,7 @@ def one_algo(key, summarizer_class, summary_kwargs):
 
 def test_naive_stack():
     summary_config_dict = {}
-    summarizer_class = naiveStack.NaiveStack
+    summarizer_class = naive_stack.NaiveStackSummarizer
     results = one_algo("NaiveStack", summarizer_class, summary_config_dict)
 
 

--- a/tests/estimation/test_summarizers.py
+++ b/tests/estimation/test_summarizers.py
@@ -7,7 +7,7 @@ import pytest
 from rail.core.data import QPHandle
 from rail.core.stage import RailStage
 from rail.core.utils import RAILDIR
-from rail.estimation.algos import naive_stack, pointEstimateHist, varInference
+from rail.estimation.algos import naive_stack, point_est_hist, varInference
 
 testdata = os.path.join(RAILDIR, "rail/examples_data/testdata/output_BPZ_lite.fits")
 DS = RailStage.data_store
@@ -35,7 +35,7 @@ def test_naive_stack():
 
 def test_point_estimate_hist():
     summary_config_dict = {}
-    summarizer_class = pointEstimateHist.PointEstimateHist
+    summarizer_class = point_est_hist.PointEstHistSummarizer
     results = one_algo("PointEstimateHist", summarizer_class, summary_config_dict)
 
 

--- a/tests/estimation/test_summarizers.py
+++ b/tests/estimation/test_summarizers.py
@@ -7,7 +7,7 @@ import pytest
 from rail.core.data import QPHandle
 from rail.core.stage import RailStage
 from rail.core.utils import RAILDIR
-from rail.estimation.algos import naive_stack, point_est_hist, varInference
+from rail.estimation.algos import naive_stack, point_est_hist, var_inf
 
 testdata = os.path.join(RAILDIR, "rail/examples_data/testdata/output_BPZ_lite.fits")
 DS = RailStage.data_store
@@ -41,5 +41,5 @@ def test_point_estimate_hist():
 
 def test_var_inference_stack():
     summary_config_dict = {}
-    summarizer_class = varInference.VarInferenceStack
+    summarizer_class = var_inf.VarInfStackSummarizer
     results = one_algo("VariationalInference", summarizer_class, summary_config_dict)


### PR DESCRIPTION
## Change Description

This PR (and other concurrent PRs in the other repos) include renamings of modules and stages within `src/rail/estimation` for consistency and transparency to users as outlined in LSSTDESC/rail#37. (Expect a few more PRs to address the smaller set of necessary consistency/clarity changes outside `src/rail/estimation` using the same branch.) 

- [x] My PR includes a link to the issue that I am addressing

I request that multiple reviewers please do not hesitate to suggest changes as needed! The goals are consistency, clarity, and longevity, so if something looks unclear, inconsistent, or insufficiently flexible to accommodate future development, now is the time to make adjustments.

## Solution Description

The following changes were made across all the rail repos, along with updates to the contributing documentation (which should be propagated to the rail python project template so prompts regarding naming are included in future PR checklists).

```
files:
  delightPZ.py --> delight_hybrid.py
  GPz.py --> _gpz_util.py
  knnpz.py --> k_nearneigh.py
  naiveStack.py --> naive_stack.py
  NZDir.py --> nz_dir.py
  pointEstimateHist.py --> point_est_hist.py
  pzflow.py --> pzflow_nf.py
  randomPZ.py --> random_gauss.py
  simpleSOM.py --> minisom_som.py
  sklearn_nn.py --> skl_neurnet.py
  somocluSOM.py --> somoclu_som.py
  trainZ.py --> train_z.py
  varInference.py --> var_inf.py
classes:
  Inform_BPZ_lite --> BPZliteInformer
  BPZ_lite --> BPZliteEstimator
  Inform_CMNNPDF --> CMNNInformer
  CMNNPDF --> CMNNEstimator
  Inform_DelightPZ --> DelightInformer
  delightPZ --> DelightEstimator  
  Inform_GPz_v1 --> GPzInformer
  GPz_v1 --> GPzEstimator
  Inform_FZBoost --> FlexZBoostInformer
  FZBoost --> FlexZBoostEstimator
  Inform_KNearNeighPDF --> KNearNeighInformer
  KNearNeighPDF --> KNearNeighEstimator
  NaiveStack --> NaiveStackSummarizer
  NZDir --> NZDirSummarizer  
  Inform_NZDir --> NZDirInformer
  PointEstimateHist --> PointEstHistSummarizer
  Inform_PZFlowPDF --> PZFlowInformer
  PZFlowPDF --> PZFlowEstimator
  RandomPZ --> RandomGaussEstimator
  Inform_SimpleNN --> SklNeurNetInformer
  SimpleNN --> SklNeurNetEstimator
  Inform_SimpleSOMSummarizer --> MiniSOMInformer
  SimpleSOMSummarizer --> MiniSOMSummarizer
  Inform_somocluSOMSummarizer --> SOMocluInformer
  somocluSOMSummarizer --> SOMocluSummarizer
  Inform_trainZ --> TrainZInformer
  TrainZ --> TrainZEstimator
  VarInferenceStack --> VarInfStackSummarizer   
```

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [X] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

Given that we are still pre-v1, I have not explicitly included backward compatibility, but a block of `import X as Y` can be constructed from the above list of changes.

### Other Change Checklist
- [X] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have updated unit/End-to-End (E2E) test cases to cover any changes

I fixed some instances of outdated descriptions in the demo notebooks, but others require more substantial editing, e.g. when they describe code that has long since been removed from the demo in question or aspects of the API that have significantly changed since the descriptions were written. The demos require a thorough review before v1 that's out of scope for this series of PRs.