### PR TITLE
change len in trainz from hardcoded value

### DIFF
--- a/src/rail/estimation/algos/train_z.py
+++ b/src/rail/estimation/algos/train_z.py
@@ -81,7 +81,7 @@ class TrainZEstimator(CatEstimator):
         self.zmode = self.model.zmode
 
     def _process_chunk(self, start, end, data, first):
-        test_size = len(data['mag_i_lsst'])
+        test_size = end - start
         zmode = np.repeat(self.zmode, test_size)
         qp_d = qp.Ensemble(qp.interp,
                            data=dict(xvals=self.zgrid, yvals=np.tile(self.train_pdf, (test_size, 1))))


### PR DESCRIPTION
This is a simple one-line change where there was a hardcoded len('mag_i_lsst') to determine the number of galaxies to make duplicate trainZ distributions for.  Now we just do end-start, which in process chunk gives us that same data length.