### PR TITLE
Issue/19/informer module

### DIFF
--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -1,5 +1,5 @@
 """
-Abstract base classes defining redshift Estimators
+Abstract base classes defining Estimators of individual galaxy redshift uncertainties
 """
 
 from rail.core.data import TableHandle, QPHandle, ModelHandle

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -1,10 +1,13 @@
 """
-Abstract base classes defining redshift estimations Informers and Estimators
+Abstract base classes defining redshift Estimators
 """
 
 from rail.core.data import TableHandle, QPHandle, ModelHandle
 from rail.core.stage import RailStage
 import gc
+
+from rail.estimation.informer import CatInformer
+# for backwards compatibility
 
 class CatEstimator(RailStage):
     """The base class for making photo-z posterior estimates from catalog-like inputs
@@ -123,59 +126,3 @@ class CatEstimator(RailStage):
 
 
 
-class CatInformer(RailStage):
-    """The base class for informing models used to make photo-z posterior estimates
-    from catalog-like inputs (i.e., tables with fluxes in photometric bands among
-    the set of columns).
-
-    Estimators use a generic "model", the details of which depends on the sub-class.
-    Most estimators will have associated Informer classes, which can be used to inform
-    those models.
-
-    (Note, "Inform" is more generic than "Train" as it also applies to algorithms that
-    are template-based rather than machine learning-based.)
-
-    Informer will produce as output a generic "model", the details of which depends on the sub-class.
-
-    They take as "input" catalog-like tabular data, which is used to "inform" the model.
-    """
-
-    name = 'Informer'
-    config_options = RailStage.config_options.copy()
-    config_options.update(hdf5_groupname=str, save_train=True)
-    inputs = [('input', TableHandle)]
-    outputs = [('model', ModelHandle)]
-
-    def __init__(self, args, comm=None):
-        """Initialize Informer that can inform models for redshift estimation """
-        RailStage.__init__(self, args, comm=comm)
-        self.model = None
-
-    def inform(self, training_data):
-        """The main interface method for Informers
-
-        This will attach the input_data to this `Informer`
-        (for introspection and provenance tracking).
-
-        Then it will call the run() and finalize() methods, which need to
-        be implemented by the sub-classes.
-
-        The run() method will need to register the model that it creates to this Estimator
-        by using `self.add_data('model', model)`.
-
-        Finally, this will return a ModelHandle providing access to the trained model.
-
-        Parameters
-        ----------
-        input_data : `dict` or `TableHandle`
-            dictionary of all input data, or a `TableHandle` providing access to it
-
-        Returns
-        -------
-        model : ModelHandle
-            Handle providing access to trained model
-        """
-        self.set_data('input', training_data)
-        self.run()
-        self.finalize()
-        return self.get_handle('model')

--- a/src/rail/estimation/informer.py
+++ b/src/rail/estimation/informer.py
@@ -9,7 +9,7 @@ from rail.core.stage import RailStage
 import gc
 
 class CatInformer(RailStage):
-    """The base class for informing models used to make photo-z posterior estimates
+    """The base class for informing models used to make photo-z data products  
     from catalog-like inputs (i.e., tables with fluxes in photometric bands among
     the set of columns).
 
@@ -66,8 +66,7 @@ class CatInformer(RailStage):
         return self.get_handle('model')
 
 class PzInformer(RailStage):
-    """The base class for informing models used to summarize photo-z posterior estimates
-    from ensembles of p(z) distributions.
+    """The base class for informing models used to make photo-z data products from existing ensembles of p(z) distributions.
 
     PzSummarizers can use a generic "model", the details of which depends on the sub-class.
     Some summaer will have associated PzInformer classes, which can be used to inform

--- a/src/rail/estimation/informer.py
+++ b/src/rail/estimation/informer.py
@@ -1,0 +1,121 @@
+"""
+Abstract base classes for Informers.
+These superstages ingest prior information, including training sets and explicit priors, and prepare a model that can be used to produce photo-z data products.
+They are distinguished by their input data types, and the models they output can be used for their corresponding Estimator, Summarizer, or Classifier stages.
+"""
+
+from rail.core.data import TableHandle, QPHandle, ModelHandle
+from rail.core.stage import RailStage
+import gc
+
+class CatInformer(RailStage):
+    """The base class for informing models used to make photo-z posterior estimates
+    from catalog-like inputs (i.e., tables with fluxes in photometric bands among
+    the set of columns).
+
+    Estimators use a generic "model", the details of which depends on the sub-class.
+    Most estimators will have associated Informer classes, which can be used to inform
+    those models.
+
+    (Note, "Inform" is more generic than "Train" as it also applies to algorithms that
+    are template-based rather than machine learning-based.)
+
+    Informer will produce as output a generic "model", the details of which depends on the sub-class.
+
+    They take as "input" catalog-like tabular data, which is used to "inform" the model.
+    """
+
+    name = 'Informer'
+    config_options = RailStage.config_options.copy()
+    config_options.update(hdf5_groupname=str, save_train=True)
+    inputs = [('input', TableHandle)]
+    outputs = [('model', ModelHandle)]
+
+    def __init__(self, args, comm=None):
+        """Initialize Informer that can inform models for redshift estimation """
+        RailStage.__init__(self, args, comm=comm)
+        self.model = None
+
+    def inform(self, training_data):
+        """The main interface method for Informers
+
+        This will attach the input_data to this `Informer`
+        (for introspection and provenance tracking).
+
+        Then it will call the run() and finalize() methods, which need to
+        be implemented by the sub-classes.
+
+        The run() method will need to register the model that it creates to this Estimator
+        by using `self.add_data('model', model)`.
+
+        Finally, this will return a ModelHandle providing access to the trained model.
+
+        Parameters
+        ----------
+        input_data : `dict` or `TableHandle`
+            dictionary of all input data, or a `TableHandle` providing access to it
+
+        Returns
+        -------
+        model : ModelHandle
+            Handle providing access to trained model
+        """
+        self.set_data('input', training_data)
+        self.run()
+        self.finalize()
+        return self.get_handle('model')
+
+class PzInformer(RailStage):
+    """The base class for informing models used to summarize photo-z posterior estimates
+    from ensembles of p(z) distributions.
+
+    PzSummarizers can use a generic "model", the details of which depends on the sub-class.
+    Some summaer will have associated PzInformer classes, which can be used to inform
+    those models.
+
+    (Note, "Inform" is more generic than "Train" as it also applies to algorithms that
+    are template-based rather than machine learning-based.)
+
+    PzInformer will produce as output a generic "model", the details of which depends on the sub-class.
+
+    They take as "input" a qp.Ensemble of per-galaxy p(z) data, which is used to "inform" the model.
+    """
+
+    name = 'Informer'
+    config_options = RailStage.config_options.copy()
+    inputs = [('input', QPHandle)]
+    outputs = [('model', ModelHandle)]
+
+    def __init__(self, args, comm=None):
+        """Initialize Informer that can inform models for redshift estimation """
+        RailStage.__init__(self, args, comm=comm)
+        self.model = None
+
+    def inform(self, training_data):
+        """The main interface method for Informers
+
+        This will attach the input_data to this `Informer`
+        (for introspection and provenance tracking).
+
+        Then it will call the run() and finalize() methods, which need to
+        be implemented by the sub-classes.
+
+        The run() method will need to register the model that it creates to this Estimator
+        by using `self.add_data('model', model)`.
+
+        Finally, this will return a ModelHandle providing access to the trained model.
+
+        Parameters
+        ----------
+        input_data :  `qp.Ensemble`
+            Per-galaxy p(z), and any ancilary data associated with it
+
+        Returns
+        -------
+        model : ModelHandle
+            Handle providing access to trained model
+        """
+        self.set_data('input', training_data)
+        self.run()
+        self.finalize()
+        return self.get_handle('model')

--- a/src/rail/estimation/summarizer.py
+++ b/src/rail/estimation/summarizer.py
@@ -4,8 +4,11 @@ Abstract base classes defining redshift estimations Informers and Estimators
 from rail.core.data import QPHandle, TableHandle, ModelHandle
 from rail.core.stage import RailStage
 
+from rail.estimation.informer import PzInformer
+# for backwards compatibility
 
-class CatSummarizer(RailStage):  #pragma: no cover
+
+class CatSummarizer(RailStage):  
     """The base class for classes that go from catalog-like tables
     to ensemble NZ estimates.
 
@@ -104,7 +107,7 @@ class PZSummarizer(RailStage):
         return self.get_handle('output')
 
 
-class SZPZSummarizer(RailStage):  #pragma: no cover
+class SZPZSummarizer(RailStage): 
     """The base class for classes that use two sets of data: a photometry sample with
     spec-z values, and a photometry sample with unknown redshifts, e.g. minisom_som and
     outputs a QP Ensemble with bootstrap realization of the N(z) distribution
@@ -187,57 +190,3 @@ class SZPZSummarizer(RailStage):  #pragma: no cover
         return self.get_handle('output')
 
 
-class PzInformer(RailStage):  #pragma: no cover
-    """The base class for informing models used to summarize photo-z posterior estimates
-    from ensembles of p(z) distributions.
-
-    PzSummarizers can use a generic "model", the details of which depends on the sub-class.
-    Some summaer will have associated PzInformer classes, which can be used to inform
-    those models.
-
-    (Note, "Inform" is more generic than "Train" as it also applies to algorithms that
-    are template-based rather than machine learning-based.)
-
-    PzInformer will produce as output a generic "model", the details of which depends on the sub-class.
-
-    They take as "input" a qp.Ensemble of per-galaxy p(z) data, which is used to "inform" the model.
-    """
-
-    name = 'Informer'
-    config_options = RailStage.config_options.copy()
-    inputs = [('input', QPHandle)]
-    outputs = [('model', ModelHandle)]
-
-    def __init__(self, args, comm=None):
-        """Initialize Informer that can inform models for redshift estimation """
-        RailStage.__init__(self, args, comm=comm)
-        self.model = None
-
-    def inform(self, training_data):
-        """The main interface method for Informers
-
-        This will attach the input_data to this `Informer`
-        (for introspection and provenance tracking).
-
-        Then it will call the run() and finalize() methods, which need to
-        be implemented by the sub-classes.
-
-        The run() method will need to register the model that it creates to this Estimator
-        by using `self.add_data('model', model)`.
-
-        Finally, this will return a ModelHandle providing access to the trained model.
-
-        Parameters
-        ----------
-        input_data :  `qp.Ensemble`
-            Per-galaxy p(z), and any ancilary data associated with it
-
-        Returns
-        -------
-        model : ModelHandle
-            Handle providing access to trained model
-        """
-        self.set_data('input', training_data)
-        self.run()
-        self.finalize()
-        return self.get_handle('model')

--- a/src/rail/estimation/summarizer.py
+++ b/src/rail/estimation/summarizer.py
@@ -1,5 +1,5 @@
 """
-Abstract base classes defining redshift estimations Informers and Estimators
+Abstract base classes defining Summarizers of the redshift distribution of an ensemble of galaxies
 """
 from rail.core.data import QPHandle, TableHandle, ModelHandle
 from rail.core.stage import RailStage


### PR DESCRIPTION
## Change & Solution Description

This addresses #19 by moving the informers to their own module so new developers can see all the types, distinguished by their inputs rather than their outputs and thus usable by an Estimator, Summarizer, or Classifier. I added a line to import the ones that used to be in estimator.py and summarizer.py in hopes that the path changes wouldn't break existing estimators/summarizers/classifiers.


## Code Quality
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code has complete unit test coverage, or I have justified any instances of `#pragma: no cover`
- [x] My code contains relevant comments and necessary documentation for future maintainers
- [x] My docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] If I have made a breaking change, I include backwards compatibility and deprecation warnings (if possible)