### PR TITLE
Adding logic to `CatEstimator` to obey `calculated_point_estimates`.

### DIFF
--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -1,6 +1,10 @@
 """
 Abstract base classes defining Estimators of individual galaxy redshift uncertainties
 """
+from typing import List
+
+import numpy as np
+from numpy.typing import NDArray
 
 from rail.core.common_params import SHARED_PARAMS
 from rail.core.data import TableHandle, QPHandle, ModelHandle
@@ -129,5 +133,107 @@ class CatEstimator(RailStage):
         self._output_handle.set_data(qp_dstn, partial=True)
         self._output_handle.write_chunk(start, end)
 
+    def _calculate_point_estimates(self, qp_dist, grid:NDArray=None) -> dict:
+        """This function drives the calculation of point estimates for qp.Ensembles.
+        It is defined here, and called from the `_process_chunk` method in the
+        CatEstimator child classes.
 
+        Parameters
+        ----------
+        qp_dist : qp.Ensemble
+            The qp Ensemble instance that contains posterior estimates.
+        grid : NDArray, optional
+            The grid on which to evaluate the point estimate. Note that not all
+            point estimates require a grid to be provided, by default None.
 
+        Returns
+        -------
+        dict
+            The ancillary dictionary that contains the point estimates. The possible
+            keys are ['mean', 'mode', 'median'].
+
+        Notes
+        -----
+        If there are particularly efficient ways to calculate point estimates for
+        a given `CatEstimator` subclass, the subclass can implement any of the
+        `_calculate_<foo>_point_estimate` for any of the point estimate calculator
+        methods:
+
+        - `_calculate_mode_point_estimate`
+        - `_calculate_mean_point_estimate`
+        - `_calculate_median_point_estimate`
+        """
+
+        ancil_dict = dict()
+        calculated_point_estimates = []
+        if 'calculated_point_estimates' in self.config:
+            calculated_point_estimates = self.config.calculated_point_estimates
+
+        if 'mode' in calculated_point_estimates:
+            mode_value = self._calculate_mode_point_estimate(qp_dist, grid)
+            ancil_dict.update(mode = mode_value)
+
+        if 'mean' in calculated_point_estimates:
+            mean_value = self._calculate_mean_point_estimate(qp_dist)
+            ancil_dict.update(mean = mean_value)
+
+        if 'median' in calculated_point_estimates:
+            median_value = self._calculate_median_point_estimate(qp_dist)
+            ancil_dict.update(median = median_value)
+
+        return ancil_dict
+
+    def _calculate_mode_point_estimate(self, qp_dist, grid:NDArray=None) -> NDArray:
+        """Calculates and returns the mode values for a set of posterior estimates
+        in a qp.Ensemble instance.
+
+        Parameters
+        ----------
+        qp_dist : qp.Ensemble
+            The qp Ensemble instance that contains posterior estimates.
+        grid : NDArray, optional
+            The grid on which to evaluate the `mode` point estimate, if a grid is
+            not provided, a default will be created at run time using `zmin`, `zmax`,
+            and `nzbins`, by default None
+
+        Returns
+        -------
+        NDArray
+            The mode value for each posterior in the qp.Ensemble
+        """
+        if grid is None:
+            grid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins)
+
+        return qp_dist.mode(grid=self.zgrid)
+
+    def _calculate_mean_point_estimate(self, qp_dist) -> NDArray:
+        """Calculates and returns the mean values for a set of posterior estimates
+        in a qp.Ensemble instance.
+
+        Parameters
+        ----------
+        qp_dist : qp.Ensemble
+            The qp Ensemble instance that contains posterior estimates.
+
+        Returns
+        -------
+        NDArray
+            The mean value for each posterior in the qp.Ensemble
+        """
+        return qp_dist.mean()
+
+    def _calculate_median_point_estimate(self, qp_dist) -> NDArray:
+        """Calculates and returns the median values for a set of posterior estimates
+        in a qp.Ensemble instance.
+
+        Parameters
+        ----------
+        qp_dist : qp.Ensemble
+            The qp Ensemble instance that contains posterior estimates.
+
+        Returns
+        -------
+        NDArray
+            The median value for each posterior in the qp.Ensemble
+        """
+        return qp_dist.median()

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -132,7 +132,7 @@ class CatEstimator(RailStage):
         self._output_handle.set_data(qp_dstn, partial=True)
         self._output_handle.write_chunk(start, end)
 
-    def _calculate_point_estimates(self, qp_dist, grid:NDArray=None):
+    def _calculate_point_estimates(self, qp_dist, grid=None):
         """This function drives the calculation of point estimates for qp.Ensembles.
         It is defined here, and called from the `_process_chunk` method in the
         `CatEstimator` child classes.
@@ -141,7 +141,7 @@ class CatEstimator(RailStage):
         ----------
         qp_dist : qp.Ensemble
             The qp Ensemble instance that contains posterior estimates.
-        grid : NDArray, optional
+        grid : array-like, optional
             The grid on which to evaluate the point estimate. Note that not all
             point estimates require a grid to be provided, by default None.
 
@@ -185,7 +185,7 @@ class CatEstimator(RailStage):
 
         return qp_dist
 
-    def _calculate_mode_point_estimate(self, qp_dist, grid:NDArray=None) -> NDArray:
+    def _calculate_mode_point_estimate(self, qp_dist, grid=None) -> NDArray:
         """Calculates and returns the mode values for a set of posterior estimates
         in a qp.Ensemble instance.
 
@@ -193,7 +193,7 @@ class CatEstimator(RailStage):
         ----------
         qp_dist : qp.Ensemble
             The qp Ensemble instance that contains posterior estimates.
-        grid : NDArray, optional
+        grid : array-like, optional
             The grid on which to evaluate the `mode` point estimate, if a grid is
             not provided, a default will be created at run time using `zmin`, `zmax`,
             and `nzbins`, by default None
@@ -202,6 +202,13 @@ class CatEstimator(RailStage):
         -------
         NDArray
             The mode value for each posterior in the qp.Ensemble
+
+        Raises
+        ------
+        KeyError
+            If `grid` is not provided, one will be created using the config parameters
+            `zmin`, `zmax`, and `nzbins`. If any of those parameters are missing,
+            we'll raise a KeyError.
         """
         if grid is None:
             for key in ['zmin', 'zmax', 'nzbins']:

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -132,7 +132,7 @@ class CatEstimator(RailStage):
         self._output_handle.set_data(qp_dstn, partial=True)
         self._output_handle.write_chunk(start, end)
 
-    def _calculate_point_estimates(self, qp_dist, grid:NDArray=None) -> dict:
+    def _calculate_point_estimates(self, qp_dist, grid:NDArray=None):
         """This function drives the calculation of point estimates for qp.Ensembles.
         It is defined here, and called from the `_process_chunk` method in the
         `CatEstimator` child classes.
@@ -147,9 +147,9 @@ class CatEstimator(RailStage):
 
         Returns
         -------
-        dict
-            The ancillary dictionary that contains the point estimates. The possible
-            keys are ['mean', 'mode', 'median'].
+        qp.Ensemble
+            The original `qp.Ensemble` with new ancillary point estimate data included.
+            The `Ensemble.ancil` keys are ['mean', 'mode', 'median'].
 
         Notes
         -----
@@ -180,7 +180,10 @@ class CatEstimator(RailStage):
             median_value = self._calculate_median_point_estimate(qp_dist)
             ancil_dict.update(median = median_value)
 
-        return ancil_dict
+        if calculated_point_estimates:
+            qp_dist.set_ancil(ancil_dict)
+
+        return qp_dist
 
     def _calculate_mode_point_estimate(self, qp_dist, grid:NDArray=None) -> NDArray:
         """Calculates and returns the mode values for a set of posterior estimates

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -217,7 +217,7 @@ class CatEstimator(RailStage):
 
             grid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins)
 
-        return qp_dist.mode(grid=self.zgrid)
+        return qp_dist.mode(grid=grid)
 
     def _calculate_mean_point_estimate(self, qp_dist) -> NDArray:
         """Calculates and returns the mean values for a set of posterior estimates

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -1,14 +1,13 @@
 """
 Abstract base classes defining Estimators of individual galaxy redshift uncertainties
 """
+import gc
 import numpy as np
 from numpy.typing import NDArray
 
 from rail.core.common_params import SHARED_PARAMS
 from rail.core.data import TableHandle, QPHandle, ModelHandle
 from rail.core.stage import RailStage
-
-import gc
 
 from rail.estimation.informer import CatInformer
 # for backwards compatibility
@@ -213,7 +212,8 @@ class CatEstimator(RailStage):
         if grid is None:
             for key in ['zmin', 'zmax', 'nzbins']:
                 if key not in self.config:
-                    raise KeyError(f"Expected `{key}` to be defined in stage configuration dictionary.")
+                    raise KeyError(f"Expected `{key}` to be defined in stage " \
+                                   "configuration dictionary in order to caluclate mode.")
 
             grid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins)
 

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -1,8 +1,6 @@
 """
 Abstract base classes defining Estimators of individual galaxy redshift uncertainties
 """
-from typing import List
-
 import numpy as np
 from numpy.typing import NDArray
 
@@ -136,7 +134,7 @@ class CatEstimator(RailStage):
     def _calculate_point_estimates(self, qp_dist, grid:NDArray=None) -> dict:
         """This function drives the calculation of point estimates for qp.Ensembles.
         It is defined here, and called from the `_process_chunk` method in the
-        CatEstimator child classes.
+        `CatEstimator` child classes.
 
         Parameters
         ----------
@@ -157,11 +155,11 @@ class CatEstimator(RailStage):
         If there are particularly efficient ways to calculate point estimates for
         a given `CatEstimator` subclass, the subclass can implement any of the
         `_calculate_<foo>_point_estimate` for any of the point estimate calculator
-        methods:
+        methods, i.e.:
 
-        - `_calculate_mode_point_estimate`
-        - `_calculate_mean_point_estimate`
-        - `_calculate_median_point_estimate`
+            - `_calculate_mode_point_estimate`
+            - `_calculate_mean_point_estimate`
+            - `_calculate_median_point_estimate`
         """
 
         ancil_dict = dict()
@@ -202,6 +200,10 @@ class CatEstimator(RailStage):
             The mode value for each posterior in the qp.Ensemble
         """
         if grid is None:
+            for key in ['zmin', 'zmax', 'nzbins']:
+                if key not in self.config:
+                    raise KeyError(f"Expected `{key}` to be defined in stage configuration dictionary.")
+
             grid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins)
 
         return qp_dist.mode(grid=self.zgrid)

--- a/tests/estimation/test_estimator.py
+++ b/tests/estimation/test_estimator.py
@@ -32,6 +32,29 @@ def test_custom_point_estimate():
 
     assert np.all(result.ancil['mode'] == MEANING_OF_LIFE)
 
+def test_basic_point_estimate():
+    """This test checks to make sure that all the basic point estimates are
+    executed when requested in the configuration dictionary.
+    """
+
+    config_dict = {'calculated_point_estimates': ['mean', 'median', 'mode'],
+                   'zmin': 0.0,
+                   'zmax': 3.0,
+                   'nzbins': 301}
+
+    test_estimator = CatEstimator.make_stage(name='test', **config_dict)
+
+    locs = 2* (np.random.uniform(size=(100,1))-0.5)
+    scales = 1 + 0.2*(np.random.uniform(size=(100,1))-0.5)
+    test_ensemble = qp.Ensemble(qp.stats.norm, data=dict(loc=locs, scale=scales))
+    result = test_estimator._calculate_point_estimates(test_ensemble, None)
+
+    # note: we're not interested in testing the values of point estimates,
+    # just that they were added to the ancillary data.
+    assert 'mode' in result.ancil
+    assert 'median' in result.ancil
+    assert 'mean' in result.ancil
+
 def test_mode_no_grid():
     """This exercises the KeyError logic in `_calculate_mode_point_estimate`.
     """

--- a/tests/estimation/test_estimator.py
+++ b/tests/estimation/test_estimator.py
@@ -1,0 +1,40 @@
+import pytest
+import numpy as np
+from numpy.typing import NDArray
+from rail.estimation.estimator import CatEstimator
+
+
+def test_custom_point_estimate():
+    """This test checks to make sure that the inheritance mechanism is working
+    for child classes of `CatEstimator`.
+    """
+
+    MEANING_OF_LIFE = 42.0
+    class TestEstimator(CatEstimator):
+        name="TestEstimator"
+
+        def __init__(self, args, comm=None):
+            CatEstimator.__init__(self, args, comm=comm)
+
+        def _calculate_mode_point_estimate(self, qp_dist=None, grid=None):
+            return np.ones(5) * MEANING_OF_LIFE
+
+    config_dict = {'calculated_point_estimates': ['mode']}
+
+    test_estimator = TestEstimator.make_stage(name='test', **config_dict)
+
+    result = test_estimator._calculate_point_estimates(None, None)
+
+    assert np.all(result['mode'] == MEANING_OF_LIFE)
+
+def test_mode_no_grid():
+    """This exercises the KeyError logic in `_calculate_mode_point_estimate`.
+    """
+    config_dict = {'zmin':0.0, 'nzbins':100, 'calculated_point_estimates': ['mode']}
+
+    test_estimator = CatEstimator.make_stage(name='test', **config_dict)
+
+    with pytest.raises(KeyError) as excinfo:
+        _ = test_estimator._calculate_point_estimates(None, None)
+
+    assert "to be defined in stage configuration" in str(excinfo.value)


### PR DESCRIPTION
This PR represents the work to move the majority of the reusable logic for calculating point estimates into the `CatEstimator` base class. This largely avoids duplicated work in the various estimator subclasses. 

When a particular estimator subclass happens to have a particularly efficient way of calculating a given point estimate, the subclass and overwrite the fine grained methods for the particular estimates. And example of this is demonstrated in the unit tests FWIW. 

One open question - would it make sense to include a call to `_calculate_point_estimates` in `_do_chunk_output`? It seems like all the subclasses make a call to that parent class method in their implementations of `_process_chunk`. If we included a call to _calculate_point_estimates there, it would save having to make updates to all the estimators. 

However, doing so also hides this functionality from the user which probably isn't what we want. I'm open to thoughts here.