### PR TITLE
Updating default inputs for estimators.

### DIFF
--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -35,6 +35,7 @@ class NaiveStackSummarizer(PZSummarizer):
                           nzbins=Param(int, 301, msg="The number of gridpoints in the z grid"),
                           seed=Param(int, 87, msg="random seed"),
                           nsamples=Param(int, 1000, msg="Number of sample distributions to create"))
+    inputs = [('input', QPHandle)]
     outputs = [('output', QPHandle),
                ('single_NZ', QPHandle)]
 

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -37,6 +37,7 @@ class PointEstHistSummarizer(PZSummarizer):
                           seed=Param(int, 87, msg="random seed"),
                           point_estimate=Param(str, 'zmode', msg="Which point estimate to use"),
                           nsamples=Param(int, 1000, msg="Number of sample distributions to return"))
+    input = [('input', QPHandle)]
     outputs = [('output', QPHandle),
                ('single_NZ', QPHandle)]
 

--- a/src/rail/estimation/algos/var_inf.py
+++ b/src/rail/estimation/algos/var_inf.py
@@ -55,6 +55,7 @@ class VarInfStackSummarizer(PZSummarizer):
                           seed=Param(int, 87, msg="random seed"),
                           niter=Param(int, 100, msg="The number of iterations in the variational inference"),
                           nsamples=Param(int, 500, msg="The number of samples used in dirichlet uncertainty"))
+    inputs = [('input', QPHandle)]
     outputs = [('output', QPHandle),
                ('single_NZ', QPHandle)]
 


### PR DESCRIPTION
See isse #58 for details

Some of the dummy estimators are causing problems due to the change to the PZSummarizer base class here: https://github.com/LSSTDESC/rail_base/pull/49/files#diff-62873f07a43e74d27e697228918f71e83c43501335e3f403d24f0664ffdced74

For the summarizers that don't require a model as input, we should override the input values to be: input = [('input', QPHandle)]

The summarizers in this category are:

- PointEstHistSummarizer
- NaiveStackSummarizer
- VarInfStackSummarizer