### PR TITLE
Raise exception when path points to non-existent file.

### DIFF
--- a/src/rail/core/stage.py
+++ b/src/rail/core/stage.py
@@ -285,6 +285,8 @@ class RailStage(PipelineStage):
         else:
             if path is None:
                 arg_data = data
+            elif not os.path.isfile(path):
+                raise FileNotFoundError(f"Unable to find file: {path}")
             else:
                 arg_data = None
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -287,3 +287,30 @@ def test_common_params():
     assert par.default == 0.1
     assert par.value == 0.1
     assert par.dtype == float
+
+
+def test_set_data_nonexistent_file():
+    """Create an instance of a child class of RailStage. Exercise the `set_data`
+    method and pass in a path to a nonexistent file. A `FileNotFound` exception
+    should be raised.
+    """
+
+    col_map = ColumnMapper.make_stage(name="col_map", columns={})
+    with pytest.raises(FileNotFoundError) as err:
+        col_map.set_data("model", None, path="./bad_directory/no_file.py")
+        assert "Unable to find file" in err.context
+
+def test_set_data_real_file():
+    """Create an instance of a child class of RailStage. Exercise the `set_data`
+    method and pass in a path to model. The output of set_data should be `None`.
+    """
+    DS = RailStage.data_store
+    DS.clear()
+    model_path = os.path.join(RAILDIR, "rail", "examples_data", "estimation_data", "data", "CWW_HDFN_prior.pkl")
+    DS.add_data("model", None, ModelHandle, path=model_path)
+
+    col_map = ColumnMapper.make_stage(name="col_map", columns={})
+
+    ret_val = col_map.set_data("model", None, path=model_path, do_read=False)
+
+    assert ret_val is None


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Add an exception when a `path` value is provided to `set_data` and it does not point to a file. 


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
