### PR TITLE
Cleaning up doc strings

### DIFF
--- a/src/rail/core/algo_utils.py
+++ b/src/rail/core/algo_utils.py
@@ -15,10 +15,10 @@ DS.__class__.allow_overwrite = True
 
 def one_algo(key, single_trainer, single_estimator, train_kwargs, estim_kwargs, is_classifier=False):
     """
-    A basic test of running an estimator subclass
+    A basic test of running an estimator subclass.
     Run inform, write temporary trained model to
     'tempmodelfile.tmp', run photo-z algorithm.
-    Then, load temp modelfile and re-run, return
+    Then, load tempmodelfile.tmp and re-run, return
     both datasets.
     """
     DS.clear()

--- a/src/rail/core/data.py
+++ b/src/rail/core/data.py
@@ -76,7 +76,7 @@ class DataHandle:
         raise NotImplementedError("DataHandle._read")  #pragma: no cover
 
     def write(self, **kwargs):
-        """Write the data to the associatied file """
+        """Write the data to the associated file """
         if self.path is None:
             raise ValueError("TableHandle.write() called but path has not been specified")
         if self.data is None:
@@ -101,7 +101,7 @@ class DataHandle:
         raise NotImplementedError("DataHandle._initialize_write") #pragma: no cover
 
     def write_chunk(self, start, end, **kwargs):
-        """Write the data to the associatied file """
+        """Write the data to the associated file """
         if self.data is None:
             raise ValueError(f"TableHandle.write_chunk() called for path {self.path} with no data")
         if self.fileObj is None:
@@ -215,7 +215,7 @@ class TableHandle(DataHandle):
 
     @classmethod
     def _write(cls, data, path, **kwargs):
-        """Write the data to the associatied file """
+        """Write the data to the associated file """
         return tables_io.write(data, path, **kwargs)
 
     @classmethod
@@ -289,7 +289,7 @@ class QPHandle(DataHandle):
 
     @classmethod
     def _write(cls, data, path, **kwargs):
-        """Write the data to the associatied file """
+        """Write the data to the associated file """
         return data.write_to(path)
 
     @classmethod
@@ -335,10 +335,12 @@ def default_model_write(model, path):
 
 class ModelDict(dict):
     """
-    A specialized dict to keep track of individual estimation models objects: this is just a dict these additional features
+    A specialized dict to keep track of individual estimation models objects.
+    This is just a dict with these additional features:
 
     1. Keys are paths
-    2. There is a read(path, force=False) method that reads a model object and inserts it into the dictionary
+    2. There is a read(path, force=False) method that reads a model object and
+    inserts it into the dictionary
     3. There is a single static instance of this class
     """
     def open(self, path, mode, **kwargs):  #pylint: disable=no-self-use
@@ -427,7 +429,7 @@ class DataStore(dict):
         return s
 
     def __setitem__(self, key, value):
-        """ Override the __setitem__ to work with `TableHandle` """
+        """ Override the __setitem__ to work with ``TableHandle`` """
         if not isinstance(value, DataHandle):
             raise TypeError(f"Can only add objects of type DataHandle to DataStore, not {type(value)}")
         check = self.get(key)

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -1,5 +1,5 @@
 """
-Abstract base classes defining Estimators of individual galaxy redshift uncertainties
+Abstract base classes defining Estimators of individual galaxy redshift uncertainties.
 """
 import gc
 
@@ -7,7 +7,6 @@ from rail.core.common_params import SHARED_PARAMS
 from rail.core.data import TableHandle, QPHandle, ModelHandle
 from rail.core.stage import RailStage
 
-from rail.estimation.informer import CatInformer
 from rail.core.point_estimation import PointEstimationMixin
 # for backwards compatibility
 
@@ -18,8 +17,8 @@ class CatEstimator(RailStage, PointEstimationMixin):
 
     Estimators use a generic "model", the details of which depends on the sub-class.
 
-    They take as "input" tabular data, apply the photo-z estimation and
-    provide as "output" a QPEnsemble, with per-object p(z).
+    Estimators take as "input" tabular data, apply the photo-z estimation and
+    provide as "output" a ``QPEnsemble``, with per-object p(z).
 
     """
 
@@ -40,18 +39,18 @@ class CatEstimator(RailStage, PointEstimationMixin):
         self.model = None
 
     def open_model(self, **kwargs):
-        """Load the mode and/or attach it to this Estimator
+        """Load the model and attach it to this Estimator
 
         Parameters
         ----------
-        model : `object`, `str` or `ModelHandle`
-            Either an object with a trained model,
-            a path pointing to a file that can be read to obtain the trained model,
-            or a `ModelHandle` providing access to the trained model.
+        model : ``object``, ``str`` or ``ModelHandle``
+            Either an object with a trained model, a path pointing to a file
+            that can be read to obtain the trained model, or a `ModelHandle`
+            providing access to the trained model.
 
         Returns
         -------
-        self.model : `object`
+        self.model : ``object``
             The object encapsulating the trained model.
         """
         model = kwargs.get('model', None)
@@ -71,25 +70,25 @@ class CatEstimator(RailStage, PointEstimationMixin):
     def estimate(self, input_data):
         """The main interface method for the photo-z estimation
 
-        This will attach the input_data to this `Estimator`
-        (for introspection and provenance tracking).
+        This will attach the input data (defined in ``inputs`` as "input") to this
+        ``Estimator`` (for introspection and provenance tracking). Then call the
+        ``run()`` and ``finalize()`` methods.
 
-        Then it will call the run() and finalize() methods, which need to
-        be implemented by the sub-classes.
+        The run method will call ``_process_chunk()``, which needs to be implemented
+        in the subclass, to process input data in batches. See ``RandomGaussEstimator``
+        for a simple example. 
 
-        The run() method will need to register the data that it creates to this Estimator
-        by using `self.add_data('output', output_data)`.
-
-        Finally, this will return a QPHandle providing access to that output data.
+        Finally, this will return a ``QPHandle`` for access to that output data.
 
         Parameters
         ----------
-        input_data : `dict` or `ModelHandle`
-            Either a dictionary of all input data or a `ModelHandle` providing access to the same
+        input_data : ``dict`` or ``ModelHandle``
+            Either a dictionary of all input data or a ``ModelHandle`` providing
+            access to the same
 
         Returns
         -------
-        output: `QPHandle`
+        output: ``QPHandle``
             Handle providing access to QP ensemble with output data
         """
         self.set_data('input', input_data)

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -7,6 +7,7 @@ from rail.core.common_params import SHARED_PARAMS
 from rail.core.data import TableHandle, QPHandle, ModelHandle
 from rail.core.stage import RailStage
 
+from rail.estimation.informer import CatInformer
 from rail.core.point_estimation import PointEstimationMixin
 # for backwards compatibility
 

--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -1,5 +1,5 @@
 """
-" Abstract base class defining an Evaluator
+Abstract base class defining an Evaluator
 
 The key feature is that the evaluate method.
 """
@@ -7,12 +7,11 @@ The key feature is that the evaluate method.
 import numpy as np
 
 from ceci.config import StageParameter as Param
+from qp.metrics.pit import PIT
 from rail.core.data import Hdf5Handle, QPHandle
 from rail.core.stage import RailStage
 from rail.core.common_params import SHARED_PARAMS
-
 from rail.evaluation.metrics.cdeloss import CDELoss
-from qp.metrics.pit import PIT
 from rail.evaluation.metrics.pointestimates import PointSigmaIQR, PointBias, PointOutlierRate, PointSigmaMAD
 
 
@@ -112,7 +111,8 @@ class Evaluator(RailStage):
             else:
                 out_table[f'PIT_{pit_metric}_stat'] = [getattr(value, 'statistic', None)]
                 out_table[f'PIT_{pit_metric}_pval'] = [getattr(value, 'p_value', None)]
-                out_table[f'PIT_{pit_metric}_significance_level'] = [getattr(value, 'significance_level', None)]
+                out_table[f'PIT_{pit_metric}_significance_level'] = \
+                    [getattr(value, 'significance_level', None)]
 
         POINT_METRICS = dict(SimgaIQR=PointSigmaIQR,
                              Bias=PointBias,

--- a/src/rail/evaluation/metrics/pointestimates.py
+++ b/src/rail/evaluation/metrics/pointestimates.py
@@ -7,17 +7,21 @@ class PointStatsEz(MetricEvaluator):
     magnitude."""
 
     def __init__(self, pzvec, szvec):
-        """An object that takes in the vectors of the point photo-z
+        """ An object that takes in the vectors of the point photo-z
         the spec-z, and the i-band magnitudes for calculating the
         point statistics
-        Parameters:
-        pzvec: Numpy 1d array of the point photo-z values
-        szvec: Numpy 1d array of the spec-z values
-        magvec: Numpy 1d array of the i-band magnitudes
-        imagcut: float: i-band magnitude cut for the sample
+
         Calculates:
-        ez: (pz-sz)/(1+sz), the quantity will be useful for
-          calculating statistics
+        ez = (pz - sz) / (1 + sz), the quantity will be useful for calculating
+        statistics
+
+
+        Parameters
+        ----------
+        pzvec : ndarray
+            Array of the point photo-z values
+        szvec : ndarray
+            array of the spec-z values
         """
         super().__init__(None)
         self.pzs = pzvec
@@ -36,11 +40,10 @@ class PointSigmaIQR(PointStatsEz):
     def evaluate(self):
         """Calculate the width of the e_z distribution
         using the Interquartile range
-        Parameters:
-        imagcut: float: i-band magnitude cut for the sample
-        Returns:
-        sigma_IQR float: width of ez distribution for full sample
-        sigma_IQR_magcut float: width of ez distribution for magcut sample
+
+        Returns
+        -------
+        ``sigma_IQR`` float. Width of ez distribution for full sample
         """
         x75, x25 = np.percentile(self.ez, [75., 25.])
         iqr = x75 - x25
@@ -55,8 +58,9 @@ class PointBias(PointStatsEz):
     """
     def evaluate(self):
         """
-        Returns:
-        bias: median of the full ez sample
+        Returns
+        -------
+        ``bias`` ndarray. Median of the full ez sample
         """
         return np.median(self.ez)
 
@@ -70,14 +74,15 @@ class PointOutlierRate(PointStatsEz):
 
     def evaluate(self):
         """
-        Returns:
-        frac: fraction of catastrophic outliers for full sample
+        Returns
+        -------
+        ``frac`` float. Fraction of catastrophic outliers for full sample
         """
         num = len(self.ez)
         sig_iqr = PointSigmaIQR(self.pzs, self.szs).evaluate()
         threesig = 3.0 * sig_iqr
         cutcriterion = np.maximum(0.06, threesig)
-        mask = (np.fabs(self.ez) > cutcriterion)
+        mask = np.fabs(self.ez) > cutcriterion
         outlier = np.sum(mask)
         frac = float(outlier) / float(num)
         return frac
@@ -91,8 +96,9 @@ class PointSigmaMAD(PointStatsEz):
 
     def evaluate(self):
         """
-        Returns:
-        sigma_mad: sigma_MAD for full sample
+        Returns
+        -------
+        ``sigma_mad`` float. Sigma median absolute deviation for full sample.
         """
         tmpmed = np.median(self.ez)
         tmpx = np.fabs(self.ez - tmpmed)

--- a/src/rail/evaluation/stats_groups.py
+++ b/src/rail/evaluation/stats_groups.py
@@ -1,4 +1,4 @@
-"""Tuples that capture standard statisical quantities """
+"""Tuples that capture standard statistical quantities """
 
 from collections import namedtuple
 


### PR DESCRIPTION
This is work that accrues to rail issue 22 (https://github.com/LSSTDESC/rail/issues/22) 

Multiple people are contributing to this PR. Generally we've broken up the rail_base repo by top level directories. In the following list, if there's a check box, it means that the directory has already been looked over. 
- [ ] cli
- [ ] core (finished algo_utils, common_param, data)
- [x] creation (#78)
- [ ] estimation (partially finished with CatEstimator)
- [x] evaluation
- [x] example_data - not really any doc strings here.
- [x] stages - no doc strings here


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
