### PR TITLE
Adding basic support for a DataHandle that reads json into a dict

### DIFF
--- a/src/rail/core/data.py
+++ b/src/rail/core/data.py
@@ -3,6 +3,7 @@
 import os
 import tables_io
 import pickle
+import json
 import qp
 
 
@@ -331,6 +332,31 @@ def default_model_write(model, path):
     """Write the model, this default implementation uses pickle"""
     with open(path, 'wb') as fout:
         pickle.dump(obj=model, file=fout, protocol=pickle.HIGHEST_PROTOCOL)
+
+
+class JsonHandle(DataHandle):
+    """Generic handle for reading in a whole file in json format as a dictionary.
+    """
+
+    suffix = 'json'
+
+    @classmethod
+    def _open(cls, path, **kwargs):
+        """Open and return the contents of the json file."""
+        return cls.read(path, **kwargs)
+
+    @classmethod
+    def _read(cls, path, **kwargs):
+        """Read the contents of the json file into a python dictionary"""
+        with open(path, "r") as infile:
+            data = json.loads(infile)
+        return data
+
+    @classmethod
+    def _write(cls, data, path, **kwargs):
+        """Write out the provided data dictionary as json."""
+        with open(path, "w") as outfile:
+            json.dumps(data, outfile)
 
 
 class ModelDict(dict):


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
This is a basic implementation of a DataHandle that is meant to read in a json file as a dictionary entirely into memory, no chunking needed. But to adhere to the ceci standard, we want to leverage the DataStore to do this. 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
