### PR TITLE
Bring parallelization up to PZClassifier

### DIFF
--- a/src/rail/estimation/algos/uniform_binning.py
+++ b/src/rail/estimation/algos/uniform_binning.py
@@ -65,8 +65,8 @@ class UniformBinningClassifier(PZClassifier):
         self._do_chunk_output(class_id, s, e, first)
 
 
-    # def _finalize_run(self):
-    #     self._output_handle.finalize_write()
+    #def _finalize_run(self):
+    #    self._output_handle.finalize_write()
 
     
     # def _do_chunk_output(self, class_id, start, end, first):

--- a/src/rail/estimation/algos/uniform_binning.py
+++ b/src/rail/estimation/algos/uniform_binning.py
@@ -3,7 +3,6 @@ A classifier that uses pz point estimate to assign
 tomographic bins with uniform binning. 
 """
 
-import gc
 import numpy as np
 from ceci.config import StageParameter as Param
 from rail.estimation.classifier import PZClassifier

--- a/src/rail/estimation/algos/uniform_binning.py
+++ b/src/rail/estimation/algos/uniform_binning.py
@@ -35,6 +35,11 @@ class UniformBinningClassifier(PZClassifier):
             zb = test_data.ancil[self.config.point_estimate]
         except KeyError:
             raise KeyError(f"{self.config.point_estimate} is not contained in the data ancil, you will need to compute it explicitly.")
+        
+        try:
+            npdf = test_data.npdf
+        except KeyError:
+            raise KeyError(f"npdf is not a supported attribute of {type(test_data)}. Are you sure you don't mean to be using a qp ensemble?")
 
         # binning options
         if len(self.config.zbin_edges)>=2:
@@ -63,32 +68,3 @@ class UniformBinningClassifier(PZClassifier):
         
         class_id = {self.config.id_name: obj_id, "class_id": bin_index}
         self._do_chunk_output(class_id, s, e, first)
-
-
-    #def _finalize_run(self):
-    #    self._output_handle.finalize_write()
-
-    
-    # def _do_chunk_output(self, class_id, start, end, first):
-    #     if first:
-    #         self._output_handle = self.add_handle('output', data=class_id)
-    #         self._output_handle.initialize_write(self._input_length, communicator=self.comm)
-    #     self._output_handle.set_data(class_id, partial=True)
-    #     self._output_handle.write_chunk(start, end)
-
-
-    # def run(self):
-    #     test_data = self.get_data('input')
-        
-    #     iterator = self.input_iterator('input') # calling RailStage's input_iterator here
-    #     first = True
-    #     self._output_handle = None
-        
-    #     for s, e, test_data in iterator:
-    #         #print(f"Process {self.rank} running estimator on chunk {s} - {e}")
-    #         self._process_chunk(s, e, test_data, first)
-    #         first = False
-    #         # Running garbage collection manually seems to be needed
-    #         # to avoid memory growth for some estimators
-    #         gc.collect()
-    #     self._finalize_run()

--- a/src/rail/estimation/algos/uniform_binning.py
+++ b/src/rail/estimation/algos/uniform_binning.py
@@ -31,10 +31,6 @@ class UniformBinningClassifier(PZClassifier):
         PZClassifier.__init__(self, args, comm=comm)
     
 
-    def _finalize_run(self):
-        self._output_handle.finalize_write()
-
-        
     def _process_chunk(self, s, e, test_data, first):
         try:
             zb = test_data.ancil[self.config.point_estimate]
@@ -70,26 +66,30 @@ class UniformBinningClassifier(PZClassifier):
         self._do_chunk_output(class_id, s, e, first)
 
 
-    def _do_chunk_output(self, class_id, start, end, first):
-        if first:
-            self._output_handle = self.add_handle('output', data=class_id)
-            self._output_handle.initialize_write(self._input_length, communicator=self.comm)
-        self._output_handle.set_data(class_id, partial=True)
-        self._output_handle.write_chunk(start, end)
+    # def _finalize_run(self):
+    #     self._output_handle.finalize_write()
+
+    
+    # def _do_chunk_output(self, class_id, start, end, first):
+    #     if first:
+    #         self._output_handle = self.add_handle('output', data=class_id)
+    #         self._output_handle.initialize_write(self._input_length, communicator=self.comm)
+    #     self._output_handle.set_data(class_id, partial=True)
+    #     self._output_handle.write_chunk(start, end)
 
 
-    def run(self):
-        test_data = self.get_data('input')
+    # def run(self):
+    #     test_data = self.get_data('input')
         
-        iterator = self.input_iterator('input') # calling RailStage's input_iterator here
-        first = True
-        self._output_handle = None
+    #     iterator = self.input_iterator('input') # calling RailStage's input_iterator here
+    #     first = True
+    #     self._output_handle = None
         
-        for s, e, test_data in iterator:
-            #print(f"Process {self.rank} running estimator on chunk {s} - {e}")
-            self._process_chunk(s, e, test_data, first)
-            first = False
-            # Running garbage collection manually seems to be needed
-            # to avoid memory growth for some estimators
-            gc.collect()
-        self._finalize_run()
+    #     for s, e, test_data in iterator:
+    #         #print(f"Process {self.rank} running estimator on chunk {s} - {e}")
+    #         self._process_chunk(s, e, test_data, first)
+    #         first = False
+    #         # Running garbage collection manually seems to be needed
+    #         # to avoid memory growth for some estimators
+    #         gc.collect()
+    #     self._finalize_run()

--- a/src/rail/estimation/algos/uniform_binning.py
+++ b/src/rail/estimation/algos/uniform_binning.py
@@ -9,9 +9,9 @@ from rail.estimation.classifier import PZClassifier
 from rail.core.data import TableHandle, Hdf5Handle
 
 class UniformBinningClassifier(PZClassifier):
-    """Classifier that simply assign tomographic
-    bins based on point estimate according to SRD"""
-
+    """Classifier that simply assigns tomographic bins based on a point estimate 
+    according to SRD.
+    """
     name = 'UniformBinningClassifier'
     config_options = PZClassifier.config_options.copy()
     config_options.update(
@@ -27,10 +27,32 @@ class UniformBinningClassifier(PZClassifier):
     
     
     def __init__(self, args, comm=None):
+        """Initialize the UniformBinningClassifier.
+
+        Parameters
+        ----------
+        args : dict
+            Configuration arguments for the classifier.
+        comm : MPI.Comm, optional
+            MPI communicator for parallel processing.
+        """
         PZClassifier.__init__(self, args, comm=comm)
     
 
-    def _process_chunk(self, s, e, test_data, first):
+    def _process_chunk(self, start, end, test_data, first):
+        """Process a chunk of data for uniform binning classification.
+
+        Parameters
+        ----------
+        start : int
+            The starting index of the chunk.
+        end : int
+            The ending index of the chunk.
+        test_data : qp.Ensemble
+            The data chunk to be processed.
+        first : bool
+            True if this is the first chunk, False otherwise.
+        """
         try:
             zb = test_data.ancil[self.config.point_estimate]
         except KeyError:
@@ -67,4 +89,4 @@ class UniformBinningClassifier(PZClassifier):
             self.config.id_name="row_index"
         
         class_id = {self.config.id_name: obj_id, "class_id": bin_index}
-        self._do_chunk_output(class_id, s, e, first)
+        self._do_chunk_output(class_id, start, end, first)

--- a/src/rail/estimation/classifier.py
+++ b/src/rail/estimation/classifier.py
@@ -149,15 +149,12 @@ class PZClassifier(RailStage):
         return self.get_handle('output')
     
 
-    # finalize run
     def _finalize_run(self):
         self._output_handle.finalize_write()
     
-    # process chunk
     def _process_chunk(self, start, end, data, first):
         raise NotImplementedError(f"{self.name}._process_chunk is not implemented")  # pragma: no cover
     
-    # do chunk output
     def _do_chunk_output(self, class_id, start, end, first):
         if first:
             self._output_handle = self.add_handle('output', data=class_id)
@@ -165,11 +162,10 @@ class PZClassifier(RailStage):
         self._output_handle.set_data(class_id, partial=True)
         self._output_handle.write_chunk(start, end)
 
-    # run
     def run(self):
         test_data = self.get_data('input')
         
-        iterator = self.input_iterator('input') # calling RailStage's input_iterator here
+        iterator = self.input_iterator('input')
         first = True
         
         for s, e, test_data in iterator:

--- a/src/rail/estimation/classifier.py
+++ b/src/rail/estimation/classifier.py
@@ -113,6 +113,8 @@ class PZClassifier(RailStage):
         """Initialize Classifier"""
         RailStage.__init__(self, args, comm=comm)
         
+        self._output_handle = None
+        
 
     def classify(self, input_data):
         """The main run method for the classifier, should be implemented
@@ -169,7 +171,6 @@ class PZClassifier(RailStage):
         
         iterator = self.input_iterator('input') # calling RailStage's input_iterator here
         first = True
-        self._output_handle = None
         
         for s, e, test_data in iterator:
             #print(f"Process {self.rank} running estimator on chunk {s} - {e}")

--- a/src/rail/estimation/classifier.py
+++ b/src/rail/estimation/classifier.py
@@ -97,12 +97,12 @@ class CatClassifier(RailStage):  #pragma: no cover
 
     
 class PZClassifier(RailStage):
-    """The base class for assigning classes (tomographic bins) to per-galaxy PZ estimates
+    """The base class for assigning classes (tomographic bins) to per-galaxy PZ 
+    estimates.
 
-    PZClassifier take as "input" a `qp.Ensemble` with per-galaxy PDFs, and
-    provide as "output" a tabular data which can be appended to the catalogue.
+    PZClassifier takes as "input" a `qp.Ensemble` with per-galaxy PDFs, and
+    provides as "output" tabular data which can be appended to the catalogue.
     """
-    
     name='PZClassifier'
     config_options = RailStage.config_options.copy()
     config_options.update(chunk_size=10000)
@@ -110,9 +110,16 @@ class PZClassifier(RailStage):
     outputs = [('output', Hdf5Handle)]
     
     def __init__(self, args, comm=None):
-        """Initialize Classifier"""
+        """Initialize the PZClassifier.
+
+        Parameters
+        ----------
+        args : dict
+            Configuration arguments for the classifier.
+        comm : MPI.Comm, optional
+            MPI communicator for parallel processing.
+        """
         RailStage.__init__(self, args, comm=comm)
-        
         self._output_handle = None
         
 
@@ -126,12 +133,16 @@ class PZClassifier(RailStage):
         Then it will call the run() and finalize() methods, which need to
         be implemented by the sub-classes.
 
-        The run() method will need to register the data that it creates to this Classifier
-        by using `self.add_data('output', output_data)`.
+        The run() method will need to register the data that it creates to this 
+        Classifier by using `self.add_data('output', output_data)`.
+
+        The run() method relies on the _process_chunk() method, which should be 
+        implemented by subclasses to perform the actual classification on each 
+        chunk of data. The results from each chunk are then combined in the 
+        _finalize_run() method. (Alternatively, override run() in a subclass to 
+        perform the classification without parallelization.)
 
         Finally, this will return a TableHandle providing access to that output data.
-
-        TODO: rewrite for parallelized version
 
         Parameters
         ----------
@@ -141,7 +152,8 @@ class PZClassifier(RailStage):
         Returns
         -------
         output: `dict`
-            Class assignment for each galaxy.
+            Class assignment for each galaxy, typically in the form of a 
+            dictionary with IDs and class labels.
         """
         self.set_data('input', input_data)
         self.run()
@@ -150,12 +162,42 @@ class PZClassifier(RailStage):
     
 
     def _finalize_run(self):
+        """Finalize the classification process after processing all chunks."""
         self._output_handle.finalize_write()
     
     def _process_chunk(self, start, end, data, first):
+        """Process a chunk of data.
+
+        This method should be implemented in subclasses to perform the actual
+        classification on a chunk of data.
+
+        Parameters
+        ----------
+        start : int
+            The starting index of the chunk.
+        end : int
+            The ending index of the chunk.
+        data : qp.Ensemble
+            The data chunk to be processed.
+        first : bool
+            True if this is the first chunk, False otherwise.
+        """
         raise NotImplementedError(f"{self.name}._process_chunk is not implemented")  # pragma: no cover
     
     def _do_chunk_output(self, class_id, start, end, first):
+        """Handle the output of a processed chunk.
+
+        Parameters
+        ----------
+        class_id : dict
+            The classification results for the chunk.
+        start : int
+            The starting index of the chunk.
+        end : int
+            The ending index of the chunk.
+        first : bool
+            True if this is the first chunk, False otherwise.
+        """
         if first:
             self._output_handle = self.add_handle('output', data=class_id)
             self._output_handle.initialize_write(self._input_length, communicator=self.comm)
@@ -163,14 +205,22 @@ class PZClassifier(RailStage):
         self._output_handle.write_chunk(start, end)
 
     def run(self):
+        """Processes the input data in chunks and performs classification.
+
+        This method iterates over chunks of the input data, calling the 
+        _process_chunk method for each chunk to perform the actual classification. 
+
+        The _process_chunk method should be implemented by subclasses to define 
+        the specific classification logic.
+        """
         test_data = self.get_data('input')
         
         iterator = self.input_iterator('input')
         first = True
         
-        for s, e, test_data in iterator:
-            #print(f"Process {self.rank} running estimator on chunk {s} - {e}")
-            self._process_chunk(s, e, test_data, first)
+        for start, end, test_data in iterator:
+            #print(f"Process {self.rank} running estimator on chunk {start} - {end}")
+            self._process_chunk(start, end, test_data, first)
             first = False
             # Running garbage collection manually seems to be needed
             # to avoid memory growth for some estimators

--- a/src/rail/estimation/classifier.py
+++ b/src/rail/estimation/classifier.py
@@ -1,6 +1,8 @@
 """
 Abstract base classes defining classifiers.
 """
+
+import gc
 from rail.core.data import QPHandle, TableHandle, ModelHandle
 from rail.core.stage import RailStage
 

--- a/src/rail/estimation/classifier.py
+++ b/src/rail/estimation/classifier.py
@@ -3,7 +3,7 @@ Abstract base classes defining classifiers.
 """
 
 import gc
-from rail.core.data import QPHandle, TableHandle, ModelHandle
+from rail.core.data import QPHandle, TableHandle, ModelHandle, Hdf5Handle
 from rail.core.stage import RailStage
 
 
@@ -107,7 +107,7 @@ class PZClassifier(RailStage):
     config_options = RailStage.config_options.copy()
     config_options.update(chunk_size=10000)
     inputs = [('input', QPHandle)]
-    outputs = [('output', TableHandle)]
+    outputs = [('output', Hdf5Handle)]
     
     def __init__(self, args, comm=None):
         """Initialize Classifier"""


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Brings parallelization code of UniformBinningClassifier up to parent PZClassifier. (While I'm not making the equal count classifier parallelized as well, that and future classifiers would now be able to run in parallel by implementing their own version of _process_chunk).

Adds in some docstrings to make the process as transparent as possible, and ideally a helpful template for anyone ramping up on rail-style parallelization in the future.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
