### PR TITLE
Added option for z_truth to be inside an hdf5 group

### DIFF
--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -25,7 +25,7 @@ class Evaluator(RailStage):
                           nzbins=Param(int, 301, msg="# of bins in zgrid"),
                           pit_metrics=Param(str, 'all', msg='PIT-based metrics to include'),
                           point_metrics=Param(str, 'all', msg='Point-estimate metrics to include'),
-                          hdf5_groupname=SHARED_PARAMS['hdf5_groupname'],
+                          hdf5_groupname=Param(str, '', msg='Name of group in hdf5 where redshift data is located'),
                           do_cde=Param(bool, True, msg='Evaluate CDE Metric'),
                           redshift_col=SHARED_PARAMS)
     inputs = [('input', QPHandle),

--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -79,7 +79,10 @@ class Evaluator(RailStage):
         """
 
         pz_data = self.get_data('input')
-        z_true = self.get_data('truth')[self.config.redshift_col]
+        if self.config.hdf5_groupname:
+                z_true = self.get_data('truth')[self.config.hdf5_groupname][self.config.redshift_col]
+        else:
+                z_true = self.get_data('truth')[self.config.redshift_col]
         zgrid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins+1)
 
         # Create an instance of the PIT class

--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -25,6 +25,7 @@ class Evaluator(RailStage):
                           nzbins=Param(int, 301, msg="# of bins in zgrid"),
                           pit_metrics=Param(str, 'all', msg='PIT-based metrics to include'),
                           point_metrics=Param(str, 'all', msg='Point-estimate metrics to include'),
+                          hdf5_groupname=SHARED_PARAMS['hdf5_groupname'],
                           do_cde=Param(bool, True, msg='Evaluate CDE Metric'),
                           redshift_col=SHARED_PARAMS)
     inputs = [('input', QPHandle),
@@ -79,10 +80,12 @@ class Evaluator(RailStage):
         """
 
         pz_data = self.get_data('input')
-        try: #pragma: no cover
-                z_true = self.get_data('truth')[self.config.hdf5_groupname][self.config.redshift_col]
-        except:
-                z_true = self.get_data('truth')[self.config.redshift_col]
+        if self.config.hdf5_groupname:
+            specz_data = self.get_data('truth')[self.config.hdf5_groupname]
+        else: 
+            specz_data = self.get_data('truth')
+        z_true = specz_data[self.config['redshift_col']]
+
         zgrid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins+1)
 
         # Create an instance of the PIT class

--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -79,9 +79,9 @@ class Evaluator(RailStage):
         """
 
         pz_data = self.get_data('input')
-        if self.config.hdf5_groupname:
+        try: #pragma: no cover
                 z_true = self.get_data('truth')[self.config.hdf5_groupname][self.config.redshift_col]
-        else:
+        except:
                 z_true = self.get_data('truth')[self.config.redshift_col]
         zgrid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins+1)
 

--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -80,7 +80,7 @@ class Evaluator(RailStage):
         """
 
         pz_data = self.get_data('input')
-        if self.config.hdf5_groupname:
+        if self.config.hdf5_groupname:  # pragma: no cover
             specz_data = self.get_data('truth')[self.config.hdf5_groupname]
         else: 
             specz_data = self.get_data('truth')

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -63,7 +63,7 @@ def test_evaluation_stage():
     pdf = DS.add_data("pdf", pdf_ens, QPHandle)
     truth_table = dict(redshift=zspec)
     truth = DS.add_data("truth", truth_table, TableHandle)
-    evaluator = Evaluator.make_stage(name="Eval", hdf5_groupname="")
+    evaluator = Evaluator.make_stage(name="Eval")
     evaluator.evaluate(pdf, truth)
 
     os.remove(evaluator.get_output(evaluator.get_aliased_tag("output"), final_name=True))

--- a/tests/evaluation/test_evaluation.py
+++ b/tests/evaluation/test_evaluation.py
@@ -63,7 +63,7 @@ def test_evaluation_stage():
     pdf = DS.add_data("pdf", pdf_ens, QPHandle)
     truth_table = dict(redshift=zspec)
     truth = DS.add_data("truth", truth_table, TableHandle)
-    evaluator = Evaluator.make_stage(name="Eval")
+    evaluator = Evaluator.make_stage(name="Eval", hdf5_groupname="")
     evaluator.evaluate(pdf, truth)
 
     os.remove(evaluator.get_output(evaluator.get_aliased_tag("output"), final_name=True))


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
If the spec-z file has truth-z inside an  h5 group (for example ['photometry']['z_true']) the evaluator needs to use hdf5_groupname to access this row.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
