### PR TITLE
Change behavior of `seed` in `Noisifier` and `Selector`

### DIFF
--- a/src/rail/creation/noisifier.py
+++ b/src/rail/creation/noisifier.py
@@ -19,7 +19,7 @@ class Noisifier(RailStage):
     name = 'Noisifier'
     config_options = RailStage.config_options.copy()
     config_options.update(
-        seed=Param(int, None, msg="If set, creates reproducible results."),
+        seed=Param(default=None, required=False, msg="Set to an `int` to force reproducible results."),
     )
     inputs = [('input', PqHandle)]
     outputs = [('output', PqHandle)]

--- a/src/rail/creation/noisifier.py
+++ b/src/rail/creation/noisifier.py
@@ -18,7 +18,9 @@ class Noisifier(RailStage):
 
     name = 'Noisifier'
     config_options = RailStage.config_options.copy()
-    config_options.update(seed=1337)
+    config_options.update(
+        seed=Param(int, None, msg="If set, creates reproducible results."),
+    )
     inputs = [('input', PqHandle)]
     outputs = [('output', PqHandle)]
 

--- a/src/rail/creation/noisifier.py
+++ b/src/rail/creation/noisifier.py
@@ -6,7 +6,7 @@ Intended subclasses are noisifier that adds LSST noise / other telescope noise
 
 from rail.core.stage import RailStage
 from rail.core.data import PqHandle
-
+from ceci.config import StageParameter as Param
 
 class Noisifier(RailStage):
     """Base class Noisifier, which adds noise to the input catalog

--- a/src/rail/creation/selector.py
+++ b/src/rail/creation/selector.py
@@ -22,6 +22,7 @@ class Selector(RailStage):
     config_options = RailStage.config_options.copy()
     config_options.update(
         drop_rows=Param(bool, True, msg="Drop selected rows from output table"),
+        seed=Param(int, None, msg="If set, creates reproducible results."),
     )
     inputs = [('input', PqHandle)]
     outputs = [('output', PqHandle)]

--- a/src/rail/creation/selector.py
+++ b/src/rail/creation/selector.py
@@ -22,7 +22,7 @@ class Selector(RailStage):
     config_options = RailStage.config_options.copy()
     config_options.update(
         drop_rows=Param(bool, True, msg="Drop selected rows from output table"),
-        seed=Param(int, None, msg="If set, creates reproducible results."),
+        seed=Param(default=None, required=False, msg="Set to an `int` to force reproducible results."),
     )
     inputs = [('input', PqHandle)]
     outputs = [('output', PqHandle)]


### PR DESCRIPTION
 Changing the seed param to be a `StageParam` and setting the default to be `None`. I could be misinterpreting the way this is intended to be used, but the sense I get (and the name implies) that `seed` should be set for reproducible results in tests, but should be None when doing science. 
