### PR TITLE
Using the new tables_io functions for the parquet file iterator

### DIFF
--- a/src/rail/core/data.py
+++ b/src/rail/core/data.py
@@ -282,7 +282,7 @@ class TableHandle(DataHandle):
         if path in [None, 'none', 'None']:  # pragma: no cover
             return 0
         try:
-            return tables_io.io.getInputDataLengthHdf5(path, **kwargs)
+            return tables_io.io.getInputDataLength(path, **kwargs)
         except Exception:
             return 0
 
@@ -367,6 +367,9 @@ class PqHandle(TableHandle):
 
     suffix = "pq"
 
+    @classmethod
+    def _size(cls, path, **kwargs):
+        return tables_io.io.getInputDataLengthPq(path, **kwargs)
 
 class QPHandle(DataHandle):
     """DataHandle for qp ensembles"""


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
