### PR TITLE
remove the bit that overwrite limits for evaluators

### DIFF
--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -350,8 +350,6 @@ class Evaluator(RailStage):
 
             sub_dict = self.config.metric_config.get("general", {}).copy()
             sub_dict.update(self.config.metric_config.get(metric_name_, {}))
-            if 'limits' in self.config:
-                sub_dict.update(dict(limits=self.config.limits))
             self._metric_config_dict[metric_name_] = sub_dict
             this_metric_class = self._metric_dict[metric_name_]
             try:

--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -347,8 +347,10 @@ class Evaluator(RailStage):
                     f"Available metrics are: {sorted(self._metric_dict.keys())}"
                 )
                 continue
-
-            sub_dict = self.config.metric_config.get("general", {}).copy()
+            sub_dict = {}
+            if 'limits' in self.config:
+                sub_dict['limits'] = self.config.limits
+            sub_dict.update(self.config.metric_config.get("general", {}))
             sub_dict.update(self.config.metric_config.get(metric_name_, {}))
             self._metric_config_dict[metric_name_] = sub_dict
             this_metric_class = self._metric_dict[metric_name_]


### PR DESCRIPTION
The line deleted will overwrite the limits set in the metric_dict to the default (0.0, 3.0). This is causing a failure in the smoke test. 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
