### PR TITLE
Fix mpi coverage in input_iterator

### DIFF
--- a/src/rail/core/stage.py
+++ b/src/rail/core/stage.py
@@ -348,8 +348,12 @@ class RailStage(PipelineStage):
             total_chunks_needed = ceil(self._input_length / self.config.chunk_size)
             # If the number of process is larger than we need, we wemove some of them
             if total_chunks_needed < self.size:  # pragma: no cover
-                color = self.rank + 1 <= total_chunks_needed
-                newcomm = self.comm.Split(color=color, key=self.rank)
+                if self.comm:
+                    color = self.rank + 1 <= total_chunks_needed
+                    newcomm = self.comm.Split(color=color, key=self.rank)
+                else:
+                    color = False
+                    newcomm = None
                 if color:
                     self.setup_mpi(newcomm)
                 else:


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
This adds a check in a RailStage input_iterator if mpi is not set up.  Previously, an AttributeError would be raised [here](https://github.com/LSSTDESC/rail_base/blob/ca6cfda6a801932882e624f3f9b42d6b0c1ce11e/src/rail/core/stage.py#L352) as `self.comm` would be `None`.  Issue #116

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
