### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pyyaml",
     "numpy",
     "click",
-    "ceci>=2",
+    "ceci>=2.0.1",
     "qp-prob>=0.8.3",
     "scipy>=1.9.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pyyaml",
     "numpy",
     "click",
-    "ceci>=1.10.1",
+    "ceci>=2",
     "qp-prob>=0.8.3",
     "scipy>=1.9.0",
 ]

--- a/src/rail/core/stage.py
+++ b/src/rail/core/stage.py
@@ -288,7 +288,7 @@ class RailStage(PipelineStage):
         if isinstance(data, DataHandle):
             aliased_tag = data.tag
             if tag in self.input_tags():
-                self.config.aliases[tag] = aliased_tag
+                self._aliases[tag] = aliased_tag
                 if data.has_path:
                     self._inputs[tag] = data.path
             arg_data = data.data

--- a/src/rail/core/stage.py
+++ b/src/rail/core/stage.py
@@ -139,7 +139,7 @@ class RailStage(PipelineStage):
     def __init__(self, args, **kwargs):
         """Constructor:
         Do RailStage specific initialization"""
-        PipelineStage.__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self._input_length = None
         self.io = StageIO(self)
 

--- a/src/rail/core/stage.py
+++ b/src/rail/core/stage.py
@@ -136,10 +136,10 @@ class RailStage(PipelineStage):
 
     data_store = DATA_STORE()
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Constructor:
         Do RailStage specific initialization"""
-        PipelineStage.__init__(self, args, comm=comm)
+        PipelineStage.__init__(self, args, **kwargs)
         self._input_length = None
         self.io = StageIO(self)
 

--- a/src/rail/creation/degrader.py
+++ b/src/rail/creation/degrader.py
@@ -23,10 +23,6 @@ class Degrader(RailStage):  # pragma: no cover
     inputs = [("input", PqHandle)]
     outputs = [("output", PqHandle)]
 
-    def __init__(self, args, comm=None):
-        """Initialize Degrader that can degrade photometric data"""
-        RailStage.__init__(self, args, comm=comm)
-
     def __call__(self, sample, seed: int = None):
         """The main interface method for ``Degrader``.
 

--- a/src/rail/creation/degraders/addRandom.py
+++ b/src/rail/creation/degraders/addRandom.py
@@ -17,13 +17,13 @@ class AddColumnOfRandom(Noisifier):
         ),
     )
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """
         Constructor
 
         Does standard Noisifier initialization
         """
-        Noisifier.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
     def _initNoiseModel(self):  # pragma: no cover
         np.random.seed(self.config.seed)

--- a/src/rail/creation/degraders/addRandom.py
+++ b/src/rail/creation/degraders/addRandom.py
@@ -23,7 +23,7 @@ class AddColumnOfRandom(Noisifier):
 
         Does standard Noisifier initialization
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
     def _initNoiseModel(self):  # pragma: no cover
         np.random.seed(self.config.seed)

--- a/src/rail/creation/degraders/quantityCut.py
+++ b/src/rail/creation/degraders/quantityCut.py
@@ -23,7 +23,7 @@ class QuantityCut(Selector):
         Performs standard Degrader initialization as well as defining the cuts
         to be applied.
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.cuts = None
         self.set_cuts(self.config["cuts"])
 

--- a/src/rail/creation/degraders/quantityCut.py
+++ b/src/rail/creation/degraders/quantityCut.py
@@ -17,13 +17,13 @@ class QuantityCut(Selector):
     config_options = Selector.config_options.copy()
     config_options.update(cuts=dict)
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Constructor.
 
         Performs standard Degrader initialization as well as defining the cuts
         to be applied.
         """
-        Selector.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.cuts = None
         self.set_cuts(self.config["cuts"])
 

--- a/src/rail/creation/engine.py
+++ b/src/rail/creation/engine.py
@@ -21,7 +21,7 @@ class Modeler(RailStage):  # pragma: no cover
 
     def __init__(self, args, **kwargs):
         """Initialize Modeler"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.model = None
 
     def fit_model(self):
@@ -58,7 +58,7 @@ class Creator(RailStage):  # pragma: no cover
 
     def __init__(self, args, **kwargs):
         """Initialize Creator"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.model = None
         if not isinstance(args, dict):  # pragma: no cover
             args = vars(args)
@@ -146,7 +146,7 @@ class PosteriorCalculator(RailStage):  # pragma: no cover
 
     def __init__(self, args, **kwargs):
         """Initialize PosteriorCalculator"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.model = None
         if not isinstance(args, dict):  # pragma: no cover
             args = vars(args)

--- a/src/rail/creation/engine.py
+++ b/src/rail/creation/engine.py
@@ -19,9 +19,9 @@ class Modeler(RailStage):  # pragma: no cover
     inputs = [("input", DataHandle)]
     outputs = [("model", ModelHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Initialize Modeler"""
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.model = None
 
     def fit_model(self):
@@ -56,9 +56,9 @@ class Creator(RailStage):  # pragma: no cover
     inputs = [("model", ModelHandle)]
     outputs = [("output", TableHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Initialize Creator"""
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.model = None
         if not isinstance(args, dict):  # pragma: no cover
             args = vars(args)
@@ -144,9 +144,9 @@ class PosteriorCalculator(RailStage):  # pragma: no cover
     ]
     outputs = [("output", QPHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Initialize PosteriorCalculator"""
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.model = None
         if not isinstance(args, dict):  # pragma: no cover
             args = vars(args)

--- a/src/rail/creation/noisifier.py
+++ b/src/rail/creation/noisifier.py
@@ -29,10 +29,6 @@ class Noisifier(RailStage):
     inputs = [("input", PqHandle)]
     outputs = [("output", PqHandle)]
 
-    def __init__(self, args, comm=None):
-        """Initialize Noisifier that can add noise to photometric data"""
-        RailStage.__init__(self, args, comm=comm)
-
     def _initNoiseModel(self):  # pragma: no cover
         raise NotImplementedError("Noisifier._initNoiseModel()")
 

--- a/src/rail/creation/selector.py
+++ b/src/rail/creation/selector.py
@@ -31,10 +31,6 @@ class Selector(RailStage):
     inputs = [("input", PqHandle)]
     outputs = [("output", PqHandle)]
 
-    def __init__(self, args, comm=None):
-        """Initialize Noisifier that can add noise to photometric data"""
-        RailStage.__init__(self, args, comm=comm)
-
     def __call__(self, sample):
         """The main interface method for ``Selector``.
 

--- a/src/rail/estimation/algos/equal_count.py
+++ b/src/rail/estimation/algos/equal_count.py
@@ -29,9 +29,6 @@ class EqualCountClassifier(PZClassifier):
     )
     outputs = [("output", TableHandle)]
 
-    def __init__(self, args, comm=None):
-        PZClassifier.__init__(self, args, comm=comm)
-
     def run(self):
         test_data = self.get_data("input")
         npdf = test_data.npdf

--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -37,7 +37,7 @@ class NaiveStackSummarizer(PZSummarizer):
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]
 
     def __init__(self, args, **kwargs):
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.zgrid = None
 
     def run(self):

--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -17,9 +17,6 @@ class NaiveStackInformer(PzInformer):
     name = "NaiveStackInformer"
     config_options = PzInformer.config_options.copy()
 
-    def __init__(self, args, comm=None):
-        PzInformer.__init__(self, args, comm=comm)
-
     def run(self):
         self.add_data("model", np.array([None]))
 
@@ -39,8 +36,8 @@ class NaiveStackSummarizer(PZSummarizer):
     inputs = [("input", QPHandle)]
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]
 
-    def __init__(self, args, comm=None):
-        PZSummarizer.__init__(self, args, comm=comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(self, args, **kwargs)
         self.zgrid = None
 
     def run(self):

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -17,9 +17,6 @@ class PointEstHistInformer(PzInformer):
     name = "PointEstHistInformer"
     config_options = PzInformer.config_options.copy()
 
-    def __init__(self, args, comm=None):
-        PzInformer.__init__(self, args, comm=comm)
-
     def run(self):
         self.add_data("model", np.array([None]))
 
@@ -40,8 +37,8 @@ class PointEstHistSummarizer(PZSummarizer):
     inputs = [("input", QPHandle)]
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]
 
-    def __init__(self, args, comm=None):
-        PZSummarizer.__init__(self, args, comm=comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(self, args, **kwargs)
         self.zgrid = None
         self.bincents = None
 

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -38,7 +38,7 @@ class PointEstHistSummarizer(PZSummarizer):
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]
 
     def __init__(self, args, **kwargs):
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.zgrid = None
         self.bincents = None
 

--- a/src/rail/estimation/algos/random_gauss.py
+++ b/src/rail/estimation/algos/random_gauss.py
@@ -20,9 +20,6 @@ class RandomGaussInformer(CatInformer):
     name = "RandomGaussInformer"
     config_options = CatInformer.config_options.copy()
 
-    def __init__(self, args, comm=None):
-        CatInformer.__init__(self, args, comm=comm)
-
     def run(self):
         self.add_data("model", np.array([None]))
 
@@ -47,10 +44,10 @@ class RandomGaussEstimator(CatEstimator):
         ),
     )
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Constructor:
         Do CatEstimator specific initialization"""
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.zgrid = None
 
     def _process_chunk(self, start, end, data, first):

--- a/src/rail/estimation/algos/random_gauss.py
+++ b/src/rail/estimation/algos/random_gauss.py
@@ -47,7 +47,7 @@ class RandomGaussEstimator(CatEstimator):
     def __init__(self, args, **kwargs):
         """Constructor:
         Do CatEstimator specific initialization"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.zgrid = None
 
     def _process_chunk(self, start, end, data, first):

--- a/src/rail/estimation/algos/train_z.py
+++ b/src/rail/estimation/algos/train_z.py
@@ -36,9 +36,6 @@ class TrainZInformer(CatInformer):
         redshift_col=SHARED_PARAMS,
     )
 
-    def __init__(self, args, comm=None):
-        CatInformer.__init__(self, args, comm=comm)
-
     def run(self):
         if self.config.hdf5_groupname:
             training_data = self.get_data("input")[self.config.hdf5_groupname]
@@ -65,11 +62,11 @@ class TrainZEstimator(CatEstimator):
     config_options = CatEstimator.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS, zmax=SHARED_PARAMS, nzbins=SHARED_PARAMS)
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         self.zgrid = None
         self.train_pdf = None
         self.zmode = None
-        CatEstimator.__init__(self, args, comm=comm)
+        CatEstimator.__init__(self, args, **kwargs)
 
     def open_model(self, **kwargs):
         CatEstimator.open_model(self, **kwargs)

--- a/src/rail/estimation/algos/true_nz.py
+++ b/src/rail/estimation/algos/true_nz.py
@@ -29,7 +29,7 @@ class TrueNZHistogrammer(RailStage):
     outputs = [("true_NZ", QPHandle)]
 
     def __init__(self, args, **kwargs):
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.zgrid = None
         self.bincents = None
 

--- a/src/rail/estimation/algos/true_nz.py
+++ b/src/rail/estimation/algos/true_nz.py
@@ -28,8 +28,8 @@ class TrueNZHistogrammer(RailStage):
     inputs = [("input", TableHandle), ("tomography_bins", TableHandle)]
     outputs = [("true_NZ", QPHandle)]
 
-    def __init__(self, args, comm=None):
-        RailStage.__init__(self, args, comm=comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(self, args, **kwargs)
         self.zgrid = None
         self.bincents = None
 

--- a/src/rail/estimation/algos/uniform_binning.py
+++ b/src/rail/estimation/algos/uniform_binning.py
@@ -36,18 +36,6 @@ class UniformBinningClassifier(PZClassifier):
     )
     outputs = [("output", Hdf5Handle)]
 
-    def __init__(self, args, comm=None):
-        """Initialize the UniformBinningClassifier.
-
-        Parameters
-        ----------
-        args : dict
-            Configuration arguments for the classifier.
-        comm : MPI.Comm, optional
-            MPI communicator for parallel processing.
-        """
-        PZClassifier.__init__(self, args, comm=comm)
-
     def _process_chunk(self, start, end, data, first):
         """Process a chunk of data for uniform binning classification.
 

--- a/src/rail/estimation/algos/var_inf.py
+++ b/src/rail/estimation/algos/var_inf.py
@@ -20,9 +20,6 @@ class VarInfStackInformer(PzInformer):
     name = "VarInfStackInformer"
     config_options = PzInformer.config_options.copy()
 
-    def __init__(self, args, comm=None):
-        PzInformer.__init__(self, args, comm=comm)
-
     def run(self):
         self.add_data("model", np.array([None]))
 
@@ -63,8 +60,8 @@ class VarInfStackSummarizer(PZSummarizer):
     inputs = [("input", QPHandle)]
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]
 
-    def __init__(self, args, comm=None):
-        PZSummarizer.__init__(self, args, comm=comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(self, args, **kwargs)
         self.zgrid = None
 
     def run(self):

--- a/src/rail/estimation/algos/var_inf.py
+++ b/src/rail/estimation/algos/var_inf.py
@@ -61,7 +61,7 @@ class VarInfStackSummarizer(PZSummarizer):
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]
 
     def __init__(self, args, **kwargs):
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.zgrid = None
 
     def run(self):

--- a/src/rail/estimation/classifier.py
+++ b/src/rail/estimation/classifier.py
@@ -23,9 +23,9 @@ class CatClassifier(RailStage):  # pragma: no cover
     inputs = [("model", ModelHandle), ("input", TableHandle)]
     outputs = [("output", TableHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Initialize Classifier"""
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self._output_handle = None
         self.model = None
         if not isinstance(args, dict):  # pragma: no cover
@@ -106,7 +106,7 @@ class PZClassifier(RailStage):
     inputs = [("input", QPHandle)]
     outputs = [("output", Hdf5Handle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Initialize the PZClassifier.
 
         Parameters
@@ -116,7 +116,7 @@ class PZClassifier(RailStage):
         comm : MPI.Comm, optional
             MPI communicator for parallel processing.
         """
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self._output_handle = None
 
     def classify(self, input_data):

--- a/src/rail/estimation/classifier.py
+++ b/src/rail/estimation/classifier.py
@@ -25,7 +25,7 @@ class CatClassifier(RailStage):  # pragma: no cover
 
     def __init__(self, args, **kwargs):
         """Initialize Classifier"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self._output_handle = None
         self.model = None
         if not isinstance(args, dict):  # pragma: no cover
@@ -116,7 +116,7 @@ class PZClassifier(RailStage):
         comm : MPI.Comm, optional
             MPI communicator for parallel processing.
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self._output_handle = None
 
     def classify(self, input_data):

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -36,9 +36,9 @@ class CatEstimator(RailStage, PointEstimationMixin):
     inputs = [("model", ModelHandle), ("input", TableHandle)]
     outputs = [("output", QPHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Initialize Estimator"""
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self._output_handle = None
         self.model = None
 

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -38,7 +38,7 @@ class CatEstimator(RailStage, PointEstimationMixin):
 
     def __init__(self, args, **kwargs):
         """Initialize Estimator"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self._output_handle = None
         self.model = None
 

--- a/src/rail/estimation/informer.py
+++ b/src/rail/estimation/informer.py
@@ -32,9 +32,9 @@ class CatInformer(RailStage):
     inputs = [("input", TableHandle)]
     outputs = [("model", ModelHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Initialize Informer that can inform models for redshift estimation"""
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.model = None
 
     def inform(self, training_data):
@@ -88,9 +88,9 @@ class PzInformer(RailStage):
     inputs = [("input", QPHandle)]
     outputs = [("model", ModelHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Initialize Informer that can inform models for redshift estimation"""
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.model = None
 
     def inform(self, training_data):

--- a/src/rail/estimation/informer.py
+++ b/src/rail/estimation/informer.py
@@ -34,7 +34,7 @@ class CatInformer(RailStage):
 
     def __init__(self, args, **kwargs):
         """Initialize Informer that can inform models for redshift estimation"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.model = None
 
     def inform(self, training_data):
@@ -90,7 +90,7 @@ class PzInformer(RailStage):
 
     def __init__(self, args, **kwargs):
         """Initialize Informer that can inform models for redshift estimation"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.model = None
 
     def inform(self, training_data):

--- a/src/rail/estimation/summarizer.py
+++ b/src/rail/estimation/summarizer.py
@@ -26,10 +26,6 @@ class CatSummarizer(RailStage):
     inputs = [("input", TableHandle)]
     outputs = [("output", QPHandle)]
 
-    def __init__(self, args, comm=None):
-        """Initialize Summarizer"""
-        RailStage.__init__(self, args, comm=comm)
-
     def summarize(self, input_data):
         """The main run method for the summarization, should be implemented
         in the specific subclass.
@@ -73,10 +69,6 @@ class PZSummarizer(RailStage):
     config_options.update(chunk_size=10000)
     inputs = [("model", ModelHandle), ("input", QPHandle)]
     outputs = [("output", QPHandle)]
-
-    def __init__(self, args, comm=None):
-        """Initialize Estimator that can sample galaxy data."""
-        RailStage.__init__(self, args, comm=comm)
 
     def summarize(self, input_data):
         """The main run method for the summarization, should be implemented
@@ -145,9 +137,9 @@ class SZPZSummarizer(RailStage):
     ]
     outputs = [("output", QPHandle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Initialize Estimator that can sample galaxy data."""
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self.model = None
         # NOTE: open model removed from init, need to put an
         # `open_model` call explicitly in the run method for

--- a/src/rail/estimation/summarizer.py
+++ b/src/rail/estimation/summarizer.py
@@ -139,7 +139,7 @@ class SZPZSummarizer(RailStage):
 
     def __init__(self, args, **kwargs):
         """Initialize Estimator that can sample galaxy data."""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self.model = None
         # NOTE: open model removed from init, need to put an
         # `open_model` call explicitly in the run method for

--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -80,7 +80,7 @@ class Evaluator(RailStage):  #pylint: disable=too-many-instance-attributes
     metric_base_class = None
 
     def __init__(self, args, **kwargs):
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self._output_handle = None
         self._summary_handle = None
         self._single_distribution_summary_handle = None

--- a/src/rail/evaluation/evaluator.py
+++ b/src/rail/evaluation/evaluator.py
@@ -79,8 +79,8 @@ class Evaluator(RailStage):  #pylint: disable=too-many-instance-attributes
 
     metric_base_class = None
 
-    def __init__(self, args, comm=None):
-        RailStage.__init__(self, args, comm=comm)
+    def __init__(self, args, **kwargs):
+        super().__init__(self, args, **kwargs)
         self._output_handle = None
         self._summary_handle = None
         self._single_distribution_summary_handle = None
@@ -414,10 +414,6 @@ class OldEvaluator(RailStage):
     )
     inputs = [("input", QPHandle), ("truth", Hdf5Handle)]
     outputs = [("output", Hdf5Handle)]
-
-    def __init__(self, args, comm=None):
-        """Initialize Evaluator"""
-        RailStage.__init__(self, args, comm=comm)
 
     def evaluate(self, data, truth):
         """Evaluate the performance of an estimator

--- a/src/rail/evaluation/single_evaluator.py
+++ b/src/rail/evaluation/single_evaluator.py
@@ -34,7 +34,7 @@ class SingleEvaluator(Evaluator):  # pylint: disable=too-many-instance-attribute
 
     def __init__(self, args, **kwargs):
         """Initialize Evaluator"""
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         self._input_data_type = QPOrTableHandle.PdfOrValue.unknown
         self._truth_data_type = QPOrTableHandle.PdfOrValue.unknown
         self._out_table = {}

--- a/src/rail/evaluation/single_evaluator.py
+++ b/src/rail/evaluation/single_evaluator.py
@@ -32,9 +32,9 @@ class SingleEvaluator(Evaluator):  # pylint: disable=too-many-instance-attribute
 
     metric_base_class = BaseMetric
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """Initialize Evaluator"""
-        Evaluator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         self._input_data_type = QPOrTableHandle.PdfOrValue.unknown
         self._truth_data_type = QPOrTableHandle.PdfOrValue.unknown
         self._out_table = {}

--- a/src/rail/tools/table_tools.py
+++ b/src/rail/tools/table_tools.py
@@ -25,9 +25,6 @@ class ColumnMapper(RailStage):
     inputs = [("input", PqHandle)]
     outputs = [("output", PqHandle)]
 
-    def __init__(self, args, comm=None):
-        RailStage.__init__(self, args, comm=comm)
-
     def run(self):
         data = self.get_data("input", allow_missing=True)
         out_data = data.rename(columns=self.config.columns, inplace=self.config.inplace)
@@ -77,9 +74,6 @@ class RowSelector(RailStage):
     inputs = [("input", PqHandle)]
     outputs = [("output", PqHandle)]
 
-    def __init__(self, args, comm=None):
-        RailStage.__init__(self, args, comm=comm)
-
     def run(self):
         data = self.get_data("input", allow_missing=True)
         out_data = data.iloc[self.config.start : self.config.stop]
@@ -121,9 +115,6 @@ class TableConverter(RailStage):
     config_options.update(output_format=str)
     inputs = [("input", PqHandle)]
     outputs = [("output", Hdf5Handle)]
-
-    def __init__(self, args, comm=None):
-        RailStage.__init__(self, args, comm=comm)
 
     def run(self):
         data = self.get_data("input", allow_missing=True)

--- a/tests/core/test_point_estimation.py
+++ b/tests/core/test_point_estimation.py
@@ -16,9 +16,6 @@ def test_custom_point_estimate():
     class TestEstimator(CatEstimator):
         name = "TestEstimator"
 
-        def __init__(self, args, comm=None):
-            CatEstimator.__init__(self, args, comm=comm)
-
         def _calculate_mode_point_estimate(self, qp_dist=None, grid=None):
             return np.ones(100) * MEANING_OF_LIFE
 


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.