### PR TITLE
fix pz factory docstring

### DIFF
--- a/src/rail/interfaces/pz_factory.py
+++ b/src/rail/interfaces/pz_factory.py
@@ -23,7 +23,7 @@ class PZFactory:
         cls,
         stage_name: str,
         stage_class: type[CatEstimator],
-        model_path: str,
+        model_path: str | dict,
         data_path: str = "none",
         **config_params: dict,
     ) -> CatEstimator:
@@ -38,8 +38,8 @@ class PZFactory:
         stage_class: type
             Python class for the stage
 
-        model_path: str
-            Path to the model file used by this estimator
+        model_path: str| dict
+            Path to the model file used by this estimator, or the model itself
 
         data_path: str
             Path to the input data, defaults to 'none'


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

trivial fix to a couple docstrings

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
