### PR TITLE
Tqz/attach useful cols

### DIFF
--- a/src/rail/core/common_params.py
+++ b/src/rail/core/common_params.py
@@ -73,6 +73,7 @@ SHARED_PARAMS = StageConfig(
     band_a_env=Param(dict, lsst_def_a_env, msg="Redenning parameters"),
     ref_band=Param(str, "mag_i_lsst", msg="band to use in addition to colors"),
     redshift_col=Param(str, "redshift", msg="name of redshift column"),
+    id_col = Param(str, "object_id", msg = "name of the object ID column"),
     object_id_col=Param(str, "objectId", msg="name of object id column"),
     zp_errors=Param(
         dtype=list,

--- a/src/rail/estimation/algos/random_gauss.py
+++ b/src/rail/estimation/algos/random_gauss.py
@@ -74,7 +74,7 @@ class RandomGaussEstimator(CatEstimator):
             ),
         )
         qp_d.set_ancil(dict(zmode=zmode))
-        self._do_chunk_output(qp_d, start, end, first)
+        self._do_chunk_output(qp_d, start, end, data, first)
 
     def validate(self) -> None:
         """Validation which checks if the required column names by the stage exist in the data"""

--- a/src/rail/estimation/algos/train_z.py
+++ b/src/rail/estimation/algos/train_z.py
@@ -103,4 +103,4 @@ class TrainZEstimator(CatEstimator):
             data=dict(xvals=self.zgrid, yvals=np.tile(self.train_pdf, (test_size, 1))),
         )
         qp_d.set_ancil(dict(zmode=zmode))
-        self._do_chunk_output(qp_d, start, end, first)
+        self._do_chunk_output(qp_d, start, end, data, first)

--- a/src/rail/evaluation/point_to_point_evaluator.py
+++ b/src/rail/evaluation/point_to_point_evaluator.py
@@ -6,6 +6,8 @@ from qp.metrics.point_estimate_metric_classes import PointToPointMetric
 
 from rail.core.data import QPHandle, TableHandle
 from rail.evaluation.evaluator import Evaluator
+from qp.metrics.base_metric_classes import BaseMetric, MetricOutputType
+from rail.core.data import DataHandle, Hdf5Handle, QPDictHandle, QPHandle
 
 
 class PointToPointEvaluator(Evaluator):
@@ -48,3 +50,105 @@ class PointToPointEvaluator(Evaluator):
         ]
 
         self._process_all_metrics(estimate_data, reference_data)
+
+        
+
+class PointToPointBinnedEvaluator(Evaluator):
+    """Evaluate the performance of a photo-z estimator against reference point estimate"""
+
+    name = "PointToPointBinnedEvaluator"
+    config_options = Evaluator.config_options.copy()
+    config_options.update(
+        hdf5_groupname=Param(
+            str, "photometry", required=False, msg="HDF5 Groupname for truth table."
+        ),
+        reference_dictionary_key=Param(
+            str,
+            "redshift",
+            required=False,
+            msg="The key in the `truth` dictionary where the redshift data is stored.",
+        ),
+        point_estimate_key=Param(
+            str, "zmode", required=False, msg="The key in the point estimate table."
+        ),
+        bin_col = Param(str, "redshift", required=False, msg="The column metrics are binned by"),
+        bin_min = Param(float, 0.0, required=False, msg="The mininum value of the binning edge"),
+        bin_max = Param(float, 3.0, required=False, msg="The maximum value of the binning edge"),
+        nbin = Param(int, 10, required=False, msg="The mininum value of the binning edge"),
+        force_exact=Param(
+            bool,
+            default=True,
+            required=False,
+            msg="Force the exact calculation.  This will not allow parallelization",
+        )
+    )
+    inputs = [("input", QPHandle), ("truth", TableHandle)]
+
+    metric_base_class = PointToPointMetric
+    
+    
+    
+    def run(self) -> None:
+        self._build_config_dict()
+
+        print(f"Requested metrics: {list(self._metric_config_dict.keys())}")
+        data = self._get_all_data()
+        estimate_data = np.squeeze(data[0].ancil[self.config.point_estimate_key])
+        reference_data = data[1][self.config.hdf5_groupname][
+            self.config.reference_dictionary_key
+        ]
+        bin_edges = np.linspace(self.config.bin_min, self.config.bin_max, self.config.nbin)
+        bin_col = data[1][self.config.hdf5_groupname][self.config.bin_col]
+        bin_indices = np.digitize(bin_col, bins=bin_edges) - 1
+        self.run_single_node()
+        table_list = []
+        
+        for i in range(len(bin_edges) - 1):
+            estimate_data_subset = estimate_data[bin_indices == i]
+            reference_data_subset = reference_data[bin_indices == i]
+            
+            summary_table = self._process_all_metrics_binned(estimate_data_subset, reference_data_subset)
+            table_list.append(summary_table)
+                    
+        out_dict = {}
+        out_dict['bin_center'] = (bin_edges[:-1]+bin_edges[1:])/2
+        metric_keys = table_list[0].keys()
+        for key in metric_keys:
+            out_dict[key] = np.array([table_list[j][key][0] for j in range(len(table_list))])
+        self._summary_handle = self.add_handle("summary", data=out_dict)
+
+
+    def _process_all_metrics_binned(self, estimate_data: Any, reference_data: Any) -> None:
+        """This function writes out metric values when operating in non-parallel mode.
+
+        Parameters
+        ----------
+        estimate_data
+            The estimated values (of the appropriate type, float or pdf) to be used
+            by the requested metrics.
+
+        reference_data
+            The reference or known values (of the appropriate type, float or pdf)
+            to be used by the requested metrics.
+
+        Raises
+        ------
+        ValueError
+            Raises an error if an unknown metric is requested.
+        """
+
+        summary_table = {}
+
+        for metric, this_metric in self._cached_metrics.items():
+            if metric not in self._metric_dict:  # pragma: no cover
+                raise ValueError(
+                    f"Unsupported metric requested: '{metric}'. "
+                    f"Available metrics are: {sorted(self._metric_dict.keys())}"
+                )
+
+            metric_result = this_metric.evaluate(estimate_data, reference_data)
+
+            if this_metric.metric_output_type == MetricOutputType.single_value:
+                summary_table[metric] = np.array([metric_result])
+
+        return summary_table


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

1. Attach object ID and redshift, if available, to the qp output. This is done in _do_chunk_output() , so every method will get it when calling this function. But the trade-off is that the _do_chunk_output() function now requires data, so that needs to be changed in every estimator. If someone has an idea of how to do this without an API-breaking change, that’d be lovely. 

2. A point-to-point evaluator class which compute the point-to-point metrics with binning, meaning you can bin the galaxies by redshift or magnitude, or anything available in the catalog, and get a list of metrics by the binning column. 

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
