### PR TITLE
Add thousands separators to progress indicator

### DIFF
--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -62,7 +62,7 @@ class NaiveStackSummarizer(PZSummarizer):
 
         first = True
         for s, e, test_data, mask in iterator:
-            print(f"Process {self.rank} running estimator on chunk {s} - {e}")
+            print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
             self._process_chunk(
                 s, e, test_data, mask, first, bootstrap_matrix, yvals, bvals
             )

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -65,7 +65,7 @@ class PointEstHistSummarizer(PZSummarizer):
 
         first = True
         for s, e, test_data, mask in iterator:
-            print(f"Process {self.rank} running estimator on chunk {s} - {e}")
+            print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
             self._process_chunk(
                 s, e, test_data, mask, first, bootstrap_matrix, single_hist, hist_vals
             )

--- a/src/rail/estimation/algos/true_nz.py
+++ b/src/rail/estimation/algos/true_nz.py
@@ -69,7 +69,7 @@ class TrueNZHistogrammer(RailStage):
 
         first = True
         for s, e, data, mask in iterator:
-            print(f"Process {self.rank} running estimator on chunk {s} - {e}")
+            print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
             self._process_chunk(s, e, data, mask, first, single_hist)
             first = False
         if self.comm is not None:  # pragma: no cover

--- a/src/rail/estimation/algos/var_inf.py
+++ b/src/rail/estimation/algos/var_inf.py
@@ -75,7 +75,7 @@ class VarInfStackSummarizer(PZSummarizer):
         self.zgrid = np.linspace(self.config.zmin, self.config.zmax, self.config.nzbins)
         first = True
         for s, e, test_data in iterator:
-            print(f"Process {self.rank} running estimator on chunk {s} - {e}")
+            print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
             alpha_trace = self._process_chunk(s, e, test_data, first)
             first = False
 

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -129,7 +129,7 @@ class CatEstimator(RailStage, PointEstimationMixin):
         self._initialize_run()
         self._output_handle = None
         for s, e, test_data in iterator:
-            print(f"Process {self.rank} running estimator on chunk {s} - {e}")
+            print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
             self._process_chunk(s, e, test_data, first)
             first = False
             # Running garbage collection manually seems to be needed


### PR DESCRIPTION
This changes the printed output of estimation stages for readability from e.g. 
```
Process 9 running estimator on chunk 53000000 - 53200000
```
to
```
Process 9 running estimator on chunk 53,000,000 - 53,200,000
```