### PR TITLE
allow no hdf5 groupname for the tomographic bin evaluator

### DIFF
--- a/src/rail/evaluation/metrics/tomography.py
+++ b/src/rail/evaluation/metrics/tomography.py
@@ -35,9 +35,14 @@ class KDEBinOverlap(RailStage):
         return self.get_handle("output")
 
     def run(self) -> None:
-        true_redshifts = self.get_handle("truth").data[self.config.hdf5_groupname][
-            self.config.redshift_col
-        ]  # 1D array of redshifts
+        if self.config.hdf5_groupname is None: # pragma: no cover
+            true_redshifts = self.get_handle("truth").data[
+                self.config.redshift_col
+            ]  # 1D array of redshifts
+        else: 
+            true_redshifts = self.get_handle("truth").data[self.config.hdf5_groupname][
+                self.config.redshift_col
+            ]  # 1D array of redshifts
         bin_indices = self.get_handle("bin_index").data[
             self.config.bin_name
         ]  # 1D array of bin indices


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
