### PR TITLE
Flush stdout before each call to _process_chunk

### DIFF
--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -3,6 +3,7 @@ Abstract base classes defining Estimators of individual galaxy redshift uncertai
 """
 
 import gc
+import sys
 from typing import Any, Optional
 
 import numpy as np
@@ -263,6 +264,7 @@ class PzEstimator(RailStage, PointEstimationMixin):
         self._output_handle = None
         for s, e, test_data in iterator:
             print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
+            sys.stdout.flush()
             self._process_chunk(s, e, test_data, first)
             first = False
             # Running garbage collection manually seems to be needed


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

When I redirect BPZ's catalog estimator to file on MacOS I don't get any logging output until right at the end due to buffering. This change adds a flush so that the user can see progress even it it is logged to file. It should have no other effects.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
