### PR TITLE
Use in-memory option rather than bugging out when handle.path is None-like

### DIFF
--- a/src/rail/core/stage.py
+++ b/src/rail/core/stage.py
@@ -487,9 +487,7 @@ class RailStage(PipelineStage):
 
         chunk_size = kwargs.get("chunk_size", self.config.chunk_size)
 
-        if handle.path:
-            if handle.path in ['None', 'none']:
-                return []            
+        if handle.path and handle.path not in ['None', 'none']:
             self._input_length = handle.size(groupname=groupname)
 
             total_chunks_needed = ceil(self._input_length / chunk_size)


### PR DESCRIPTION
Hi @eacharles , sorry for PR.  I needed this additional change for our in-memory code to work.  I thought I had a workaround before, but apparently I was confused.

I know nothing about the overall architecture here and probably shouldn't be brave enough to make a PR.  But it seems to me that handle.path is almost always 'None' or 'none' (including for set_data('input', data) in-memory calls), and so the logic here leads to taking the return [] path even for the in-memory case.  I've changed the logic to treat handle.path in [None, 'None', 'none'] equivalently, rather than taking one path for None and another path for ['None', 'none'].  That fixes my narrow use case but I am misunderstanding the larger context.
