### PR TITLE
Format converter

### DIFF
--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -213,6 +213,7 @@ class CatEstimator(RailStage, PointEstimationMixin):
         """
         Utility function to convert existing Tabular data to a numpy dictionary,
         ingestable for most informer and estimators.
+        To be called in _process_chunk().
         """
         # required format for informer/estimator
         out_fmt = tables_io.types.TABULAR_FORMAT_NAMES["numpyDict"] 

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -209,6 +209,18 @@ class CatEstimator(RailStage, PointEstimationMixin):
         return qp_dstn
 
 
+    def _convert_table_to_numpyDict(data: TableLike) -> TableLike:
+        """
+        Utility function to convert existing Tabular data to a numpy dictionary,
+        ingestable for most informer and estimators.
+        """
+        # required format for informer/estimator
+        out_fmt = tables_io.types.TABULAR_FORMAT_NAMES["numpyDict"] 
+        out_data = tables_io.convert(data, out_fmt)
+        # overwrite set_data
+        return out_data
+
+
 class PzEstimator(RailStage, PointEstimationMixin):
     """The base class for making photo-z posterior estimates from other pz inputs
 

--- a/src/rail/estimation/estimator.py
+++ b/src/rail/estimation/estimator.py
@@ -18,6 +18,7 @@ from rail.core.enums import DistributionType
 
 # for backwards compatibility, to avoid break stuff that imports it from here
 from .informer import CatInformer  # pylint: disable=unused-import
+import tables_io
 
 
 class CatEstimator(RailStage, PointEstimationMixin):
@@ -209,14 +210,14 @@ class CatEstimator(RailStage, PointEstimationMixin):
         return qp_dstn
 
 
-    def _convert_table_to_numpyDict(data: TableLike) -> TableLike:
+    def _convert_table_to_numpyDict(data: TableLike, out_fmt_str: str="numpyDict") -> TableLike:
         """
         Utility function to convert existing Tabular data to a numpy dictionary,
         ingestable for most informer and estimators.
         To be called in _process_chunk().
         """
         # required format for informer/estimator
-        out_fmt = tables_io.types.TABULAR_FORMAT_NAMES["numpyDict"] 
+        out_fmt = tables_io.types.TABULAR_FORMAT_NAMES[out_fmt_str] 
         out_data = tables_io.convert(data, out_fmt)
         # overwrite set_data
         return out_data

--- a/src/rail/estimation/informer.py
+++ b/src/rail/estimation/informer.py
@@ -79,14 +79,14 @@ class CatInformer(RailStage):
         self.finalize()
         return self.get_handle("model")
 
-    def _convert_table_to_numpyDict(data: TableLike) -> TableLike:
+    def _convert_table_to_numpyDict(data: TableLike, out_fmt_str: str="numpyDict") -> TableLike:
         """
         Utility function to convert existing Tabular data to a numpy dictionary,
         ingestable for most informer and estimators.
         To be called in run().
         """
         # required format for informer/estimator
-        out_fmt = tables_io.types.TABULAR_FORMAT_NAMES["numpyDict"] 
+        out_fmt = tables_io.types.TABULAR_FORMAT_NAMES[out_fmt_str] 
         out_data = tables_io.convert(data, out_fmt)
         # overwrite set_data
         return out_data

--- a/src/rail/estimation/informer.py
+++ b/src/rail/estimation/informer.py
@@ -83,6 +83,7 @@ class CatInformer(RailStage):
         """
         Utility function to convert existing Tabular data to a numpy dictionary,
         ingestable for most informer and estimators.
+        To be called in run().
         """
         # required format for informer/estimator
         out_fmt = tables_io.types.TABULAR_FORMAT_NAMES["numpyDict"] 

--- a/src/rail/estimation/informer.py
+++ b/src/rail/estimation/informer.py
@@ -15,6 +15,7 @@ from rail.core.common_params import SHARED_PARAMS
 from rail.core.data import (DataHandle, ModelHandle, QPHandle, TableHandle,
                             TableLike)
 from rail.core.stage import RailStage
+import tables_io
 
 
 class CatInformer(RailStage):
@@ -78,6 +79,17 @@ class CatInformer(RailStage):
         self.finalize()
         return self.get_handle("model")
 
+    def _convert_table_to_numpyDict(data: TableLike) -> TableLike:
+        """
+        Utility function to convert existing Tabular data to a numpy dictionary,
+        ingestable for most informer and estimators.
+        """
+        # required format for informer/estimator
+        out_fmt = tables_io.types.TABULAR_FORMAT_NAMES["numpyDict"] 
+        out_data = tables_io.convert(data, out_fmt)
+        # overwrite set_data
+        return out_data
+        
 
 class PzInformer(RailStage):
     """The base class for informing models used to make photo-z data products from


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Addressing #222 
Adding a utility function in the informer and estimator base class to convert input data format to required output format used by the informer / estimators. This will need to be called in run() or _process_chunks() for informer / estimator.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
