### PR TITLE
Swap outdated filter in lsst.para lephare config file #224

### DIFF
--- a/src/rail/examples_data/estimation_data/data/lsst.para
+++ b/src/rail/examples_data/estimation_data/data/lsst.para
@@ -29,7 +29,7 @@ AGE_RANGE  0.,15.e9                                     # Age Min-Max in yr
 
 # 
 FILTER_REP   $LEPHAREDIR/filt           # Repository in which the filters are stored
-FILTER_LIST   lsst/total_u.pb,lsst/total_g.pb,lsst/total_r.pb,lsst/total_i.pb,lsst/total_z.pb,lsst/total_y3.pb
+FILTER_LIST   lsst/total_u.pb,lsst/total_g.pb,lsst/total_r.pb,lsst/total_i.pb,lsst/total_z.pb,lsst/total_y.pb
 TRANS_TYPE	 1			# TRANSMISSION TYPE
                                         # 0[-def]: Energy, 1: Nb of photons
 FILTER_CALIB    0,0,0,0,0,0             # 0[-def]:  fnu=ctt 


### PR DESCRIPTION
addresses #224, Lephare NB is looking for a since removed filter file, change the name in the src/rail/examples_data/estimation_data/data/lsst.para file.  

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
