### PR TITLE
Minor fix for SingleEvaluator and update to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "ceci>=2.1",
     "qp-prob>=1.0.0",
     "scipy>=1.9.0",
+    "setuptools>=62", # Used to manage connections between RAIL packages
 ]
 
 

--- a/src/rail/evaluation/single_evaluator.py
+++ b/src/rail/evaluation/single_evaluator.py
@@ -204,7 +204,7 @@ class SingleEvaluator(Evaluator):  # pylint: disable=too-many-instance-attribute
                         self._process_all_point_to_point(
                             this_metric,
                             key_val,
-                            point_data,
+                            np.squeeze(point_data),
                             truth_data[truth_point_estimate_],
                         )
             elif (


### PR DESCRIPTION
## Problem & Solution Description 

SingleEvaluator was not passing its test on my computer, since it was trying to subtract an (n,1) and (n,) array in `_process_all_point_to_point`. I added np.squeeze to ensure the data is a 1D array 

Added setuptools to the base dependencies because it's not just used to set up the package but also in  core/introspection.py 


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
