### PR TITLE
fix mag_limits to use column name instead of band_name

### DIFF
--- a/src/rail/utils/catalog_tag.py
+++ b/src/rail/utils/catalog_tag.py
@@ -236,7 +236,7 @@ class CatalogTag(Configurable):
             bands.append(mag_column_name)
             err_bands.append(mag_err_column_name)
             err_dict[mag_column_name] = mag_err_column_name
-            mag_limits[band_name] = band_info["mag_limit"]
+            mag_limits[mag_column_name] = band_info["mag_limit"]
             if "zp_error" in band_info:  # pragma: no cover
                 zp_err = band_info["zp_error"]
             else:


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
