### PR TITLE
add bit to build_and_write to change nprocess and max_thread

### DIFF
--- a/src/rail/core/stage.py
+++ b/src/rail/core/stage.py
@@ -186,7 +186,7 @@ class RailPipeline(MiniPipeline):
         )
 
         # make sure stage_config_dict is a dict of stages_config
-        if isinstance(stages_config, str):
+        if isinstance(stages_config, str): # pragma: no cover
             with open(stages_config, "r") as f:
                 stages_config_dict = yaml.safe_load(f) or {}
         else:
@@ -199,14 +199,15 @@ class RailPipeline(MiniPipeline):
         
             if nprocess is None:
                 continue
+            else: # pragma: no cover
         
-            exec_cfg.nprocess = nprocess
-        
-            # bump max_threads if needed
-            site_cfg = exec_cfg.site.config
-            if nprocess > site_cfg.get("max_threads", 0):
-                print(f"{class_name} update max_threads to {nprocess}")
-                site_cfg["max_threads"] = nprocess
+                exec_cfg.nprocess = nprocess
+            
+                # bump max_threads if needed
+                site_cfg = exec_cfg.site.config
+                if nprocess > site_cfg.get("max_threads", 0):
+                    print(f"{class_name} update max_threads to {nprocess}")
+                    site_cfg["max_threads"] = nprocess
         pipe.save(output_yaml)
 
     def __init__(self) -> None:


### PR DESCRIPTION
The build_and_write will pick up 'nprocess' in any stage and change the corresponding nprocess in the rail pipeline yaml, as well as max_thread if nprocess is greater than the current max_thread.


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
