### PR TITLE
Allow passing special value to indicate that masked summarizers should select any bin>=0

### DIFF
--- a/src/rail/core/common_params.py
+++ b/src/rail/core/common_params.py
@@ -188,3 +188,6 @@ copy_param = SharedParams.copy_param
 set_param_default = SharedParams.set_param_default
 
 set_param_defaults = SharedParams.set_param_defaults
+
+TOMOGRAPHY_NONE = -1
+TOMOGRAPHY_ALL = -2

--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -9,7 +9,7 @@ import qp
 from ceci.config import StageParameter as Param
 
 from rail.core.data import QPHandle, TableHandle, TableLike
-from rail.core.common_params import SharedParams
+from rail.core.common_params import SharedParams, TOMOGRAPHY_ALL, TOMOGRAPHY_NONE
 from rail.estimation.informer import PzInformer
 from rail.estimation.summarizer import PZSummarizer
 
@@ -151,7 +151,7 @@ class NaiveStackMaskedSummarizer(NaiveStackSummarizer):
     interactive_function = "naive_stack_masked_summarizer"
     config_options = NaiveStackSummarizer.config_options.copy()
     config_options.update(
-        selected_bin=Param(int, -1, msg="bin to use, or 'all' for all bins >=0 or 'none' for no masking"),
+        selected_bin=Param(int, TOMOGRAPHY_NONE, msg=f"bin to use, or {TOMOGRAPHY_ALL} for all bins >=0 or {TOMOGRAPHY_NONE} for no masking"),
     )
     inputs = [("input", QPHandle), ("tomography_bins", TableHandle)]
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]
@@ -159,9 +159,9 @@ class NaiveStackMaskedSummarizer(NaiveStackSummarizer):
     def _setup_iterator(self) -> Generator:
         selected_bin = self.config.selected_bin
         if self.config.tomography_bins in ["none", None]:
-            selected_bin = -1
+            selected_bin = TOMOGRAPHY_NONE
 
-        if selected_bin == -1:
+        if selected_bin == TOMOGRAPHY_NONE:
             itrs = [self.input_iterator("input")]
         else:
             itrs = [
@@ -179,7 +179,7 @@ class NaiveStackMaskedSummarizer(NaiveStackSummarizer):
                     pz_data = d
                     first = False
                 else:
-                    if selected_bin == "all":
+                    if selected_bin == TOMOGRAPHY_ALL:
                         mask = d["class_id"] >= 0
                     else:
                         mask = d["class_id"] == selected_bin

--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -182,7 +182,7 @@ class NaiveStackMaskedSummarizer(NaiveStackSummarizer):
                     if selected_bin == "all":
                         mask = d["class_id"] >= 0
                     else:
-                        mask = d["class_id"] == self.config.selected_bin
+                        mask = d["class_id"] == selected_bin
             if mask is None:
                 mask = np.ones(
                     pz_data.npdf,  # pylint: disable=possibly-used-before-assignment

--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -179,7 +179,10 @@ class NaiveStackMaskedSummarizer(NaiveStackSummarizer):
                     pz_data = d
                     first = False
                 else:
-                    mask = d["class_id"] == self.config.selected_bin
+                    if selected_bin == "all":
+                        mask = d["class_id"] >= 0
+                    else:
+                        mask = d["class_id"] == self.config.selected_bin
             if mask is None:
                 mask = np.ones(
                     pz_data.npdf,  # pylint: disable=possibly-used-before-assignment

--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -151,7 +151,7 @@ class NaiveStackMaskedSummarizer(NaiveStackSummarizer):
     interactive_function = "naive_stack_masked_summarizer"
     config_options = NaiveStackSummarizer.config_options.copy()
     config_options.update(
-        selected_bin=Param(int, -1, msg="bin to use"),
+        selected_bin=Param(int, -1, msg="bin to use, or 'all' for all bins >=0 or 'none' for no masking"),
     )
     inputs = [("input", QPHandle), ("tomography_bins", TableHandle)]
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -152,7 +152,7 @@ class PointEstHistMaskedSummarizer(PointEstHistSummarizer):
                     if selected_bin == "all":
                         mask = d["class_id"] >= 0
                     else:
-                        mask = d["class_id"] == self.config.selected_bin
+                        mask = d["class_id"] == selected_bin
             if mask is None:
                 mask = np.ones(
                     pz_data.npdf,  # pylint: disable=possibly-used-before-assignment

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -9,7 +9,7 @@ import qp
 from ceci.config import StageParameter as Param
 
 from rail.core.data import QPHandle, TableHandle, TableLike
-from rail.core.common_params import SharedParams
+from rail.core.common_params import SharedParams, TOMOGRAPHY_ALL, TOMOGRAPHY_NONE
 from rail.estimation.informer import PzInformer
 from rail.estimation.summarizer import PZSummarizer
 
@@ -121,7 +121,7 @@ class PointEstHistMaskedSummarizer(PointEstHistSummarizer):
     interactive_function = "point_est_hist_masked_summarizer"
     config_options = PointEstHistSummarizer.config_options.copy()
     config_options.update(
-        selected_bin=Param(int, -1, msg="bin to use, or 'all' for all bins >=0 or 'none' for no masking")
+        selected_bin=Param(int, TOMOGRAPHY_NONE, msg=f"bin to use, or {TOMOGRAPHY_ALL} for all bins >=0 or {TOMOGRAPHY_NONE} for no masking")
     )
     inputs = [("input", QPHandle), ("tomography_bins", TableHandle)]
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]
@@ -129,9 +129,9 @@ class PointEstHistMaskedSummarizer(PointEstHistSummarizer):
     def _setup_iterator(self) -> Generator:
         selected_bin = self.config.selected_bin
         if self.config.tomography_bins in ["none", None]:
-            selected_bin = -1
+            selected_bin = TOMOGRAPHY_NONE
 
-        if selected_bin == -1:
+        if selected_bin == TOMOGRAPHY_NONE:
             itrs = [self.input_iterator("input")]
         else:
             itrs = [
@@ -149,7 +149,7 @@ class PointEstHistMaskedSummarizer(PointEstHistSummarizer):
                     pz_data = d
                     first = False
                 else:
-                    if selected_bin == "all":
+                    if selected_bin == TOMOGRAPHY_ALL:
                         mask = d["class_id"] >= 0
                     else:
                         mask = d["class_id"] == selected_bin

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -149,7 +149,10 @@ class PointEstHistMaskedSummarizer(PointEstHistSummarizer):
                     pz_data = d
                     first = False
                 else:
-                    mask = d["class_id"] == self.config.selected_bin
+                    if selected_bin == "all":
+                        mask = d["class_id"] >= 0
+                    else:
+                        mask = d["class_id"] == self.config.selected_bin
             if mask is None:
                 mask = np.ones(
                     pz_data.npdf,  # pylint: disable=possibly-used-before-assignment

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -121,7 +121,7 @@ class PointEstHistMaskedSummarizer(PointEstHistSummarizer):
     interactive_function = "point_est_hist_masked_summarizer"
     config_options = PointEstHistSummarizer.config_options.copy()
     config_options.update(
-        selected_bin=Param(int, -1, msg="bin to use"),
+        selected_bin=Param(int, -1, msg="bin to use, or 'all' for all bins >=0 or 'none' for no masking")
     )
     inputs = [("input", QPHandle), ("tomography_bins", TableHandle)]
     outputs = [("output", QPHandle), ("single_NZ", QPHandle)]

--- a/tests/estimation/test_summarizers.py
+++ b/tests/estimation/test_summarizers.py
@@ -7,6 +7,7 @@ from rail.core.data import QPHandle, TableHandle
 from rail.core.stage import RailStage
 from rail.estimation.algos import naive_stack, point_est_hist, var_inf
 from rail.utils.path_utils import RAILDIR
+from rail.core.common_params import TOMOGRAPHY_ALL, TOMOGRAPHY_NONE
 
 testdata = os.path.join(RAILDIR, "rail/examples_data/testdata/output_BPZ_lite.hdf5")
 tomobins = os.path.join(RAILDIR, "rail/examples_data/testdata/output_tomo.hdf5")
@@ -48,8 +49,9 @@ def one_mask_algo(
     # tomo_bins = DS.read_file("tomo_bins", TableHandle, tomobins)
     test_data = QPHandle("test_data", path=testdata)
     tomo_bins = TableHandle("tomo_bins", path=tomobins)
+    selected_bin = summary_kwargs.get("selected_bin", 1)
 
-    summarizer = summarizer_class.make_stage(name=key, selected_bin=1, **summary_kwargs)
+    summarizer = summarizer_class.make_stage(name=key, selected_bin=selected_bin, **summary_kwargs)
     summary_ens = summarizer.summarize(test_data, tomo_bins)
     os.remove(
         summarizer.get_output(summarizer.get_aliased_tag("output"), final_name=True)
@@ -126,6 +128,8 @@ def test_naive_stack_masked() -> None:
     )
     summarizer_class = naive_stack.NaiveStackMaskedSummarizer
     _ = one_mask_algo("NaiveStack", summarizer_class, summary_config_dict)
+    _ = one_mask_algo("NaiveStack", summarizer_class, summary_config_dict | {"selected_bin": TOMOGRAPHY_ALL})
+    _ = one_mask_algo("NaiveStack", summarizer_class, summary_config_dict | {"selected_bin": TOMOGRAPHY_NONE})
     _ = one_algo("NaiveStack", summarizer_class, summary_config_dict)
 
 

--- a/tests/estimation/test_summarizers.py
+++ b/tests/estimation/test_summarizers.py
@@ -49,7 +49,8 @@ def one_mask_algo(
     # tomo_bins = DS.read_file("tomo_bins", TableHandle, tomobins)
     test_data = QPHandle("test_data", path=testdata)
     tomo_bins = TableHandle("tomo_bins", path=tomobins)
-    selected_bin = summary_kwargs.get("selected_bin", 1)
+    summary_kwargs = summary_kwargs.copy()
+    selected_bin = summary_kwargs.pop("selected_bin", 1)
 
     summarizer = summarizer_class.make_stage(name=key, selected_bin=selected_bin, **summary_kwargs)
     summary_ens = summarizer.summarize(test_data, tomo_bins)
@@ -142,4 +143,6 @@ def test_point_estimate_hist_masked() -> None:
     )
     summarizer_class = point_est_hist.PointEstHistMaskedSummarizer
     _ = one_mask_algo("PointEstimateHist", summarizer_class, summary_config_dict)
+    _ = one_mask_algo("PointEstimateHist", summarizer_class, summary_config_dict | {"selected_bin": TOMOGRAPHY_ALL})
+    _ = one_mask_algo("PointEstimateHist", summarizer_class, summary_config_dict | {"selected_bin": TOMOGRAPHY_NONE})
     _ = one_algo("PointEstimateHist", summarizer_class, summary_config_dict)


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

This allows passing the string "all" as the `selected_bin` configuration option to the `NaiveStackSummarizer` and `PointEstHistMaskedSummarizer` classes. In that case any non-negative tomographic bin index objects will be selected, allowing us to run a non-tomographic analysis alongside a tomnographic one without duplicated data.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
