### PR TITLE
set the create_interactive_structure to only run on the first of the month

### DIFF
--- a/.github/workflows/run-create-interactive-structure.yml
+++ b/.github/workflows/run-create-interactive-structure.yml
@@ -7,12 +7,8 @@
 name: Running create_interactive_structure script
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
   schedule:
-    - cron: 30 5 * * 2
+    - cron: 30 5 1 * *
 
 jobs:
   build:


### PR DESCRIPTION
## Problem & Solution Description (including issue #)


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
