### PR TITLE
Change from traditional bootstrap to Poisson

### DIFF
--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -134,8 +134,8 @@ class NaiveStackSummarizer(PZSummarizer):
             0,
         )
         # qp_d is the normalized probability of the stack, we need to know how many galaxies were
+        rng = np.random.default_rng(seed=[self.config.seed, start])
         for i in range(self.config.n_samples):
-            rng = np.random.default_rng(seed=[self.config.seed, start])
             # This is Poisson bootstrap, a variant of regular bootstrap
             # that does not require anything to be stored or comunicated between
             # processes. For large numbers of objects this converges to the same

--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -92,13 +92,12 @@ class NaiveStackSummarizer(PZSummarizer):
         # Initializing the stacking pdf's
         yvals = np.zeros((1, len(self.zgrid)))
         bvals = np.zeros((self.config.n_samples, len(self.zgrid)))
-        bootstrap_matrix = self._broadcast_bootstrap_matrix()
 
         first = True
         for s, e, test_data, mask in iterator:
             print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
             self._process_chunk(
-                s, e, test_data, mask, first, bootstrap_matrix, yvals, bvals
+                s, e, test_data, mask, first, yvals, bvals
             )
             first = False
         if self.comm is not None:  # pragma: no cover
@@ -119,7 +118,6 @@ class NaiveStackSummarizer(PZSummarizer):
         data: qp.Ensemble,
         mask: np.ndarray,
         _first: bool,
-        bootstrap_matrix: np.ndarray,
         yvals: np.ndarray,
         bvals: np.ndarray,
     ) -> None:
@@ -137,12 +135,9 @@ class NaiveStackSummarizer(PZSummarizer):
         )
         # qp_d is the normalized probability of the stack, we need to know how many galaxies were
         for i in range(self.config.n_samples):
-            bootstrap_draws = bootstrap_matrix[:, i]
-            # Neither all of the bootstrap_draws are in this chunk nor the index starts at "start"
-            chunk_mask = (bootstrap_draws >= start) & (bootstrap_draws < end)
-            bootstrap_draws = bootstrap_draws[chunk_mask] - start
-            zarr = np.where(squeeze_mask, pdf_vals.T, 0.0).T[bootstrap_draws]
-            bvals[i] += np.sum(zarr, axis=0)
+            rng = np.random.default_rng(seed=[self.config.seed, start])
+            bootstrap_weights = rng.poisson(lam=1.0, size=pdf_vals.shape[0])
+            bvals[i] += bootstrap_weights[squeeze_mask] @ pdf_vals[squeeze_mask]
 
 
 class NaiveStackMaskedSummarizer(NaiveStackSummarizer):

--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -136,6 +136,10 @@ class NaiveStackSummarizer(PZSummarizer):
         # qp_d is the normalized probability of the stack, we need to know how many galaxies were
         for i in range(self.config.n_samples):
             rng = np.random.default_rng(seed=[self.config.seed, start])
+            # This is Poisson bootstrap, a variant of regular bootstrap
+            # that does not require anything to be stored or comunicated between
+            # processes. For large numbers of objects this converges to the same
+            # distribution as regular bootstrap.
             bootstrap_weights = rng.poisson(lam=1.0, size=pdf_vals.shape[0])
             bvals[i] += bootstrap_weights[squeeze_mask] @ pdf_vals[squeeze_mask]
 

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -106,7 +106,7 @@ class PointEstHistSummarizer(PZSummarizer):
         # by using the chunk start index and the base seed together
         rng = np.random.default_rng(seed=[self.config.seed, start])
         for i in range(self.config.n_samples):
-            # poisson bootstrap
+            # poisson bootstrap - see naive_stack.py comment for details.
             bootstrap_weights = rng.poisson(lam=1.0, size=zb.size)
             hist_vals[i] += np.histogram(zb, weights=bootstrap_weights, bins=self.zgrid)[0]
 

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -64,7 +64,6 @@ class PointEstHistSummarizer(PZSummarizer):
         )
         assert self.zgrid is not None
         self.bincents = 0.5 * (self.zgrid[1:] + self.zgrid[:-1])
-        bootstrap_matrix = self._broadcast_bootstrap_matrix()
         # Initiallizing the histograms
         single_hist = np.zeros(self.config.nzbins)
         hist_vals = np.zeros((self.config.n_samples, self.config.nzbins))
@@ -73,7 +72,7 @@ class PointEstHistSummarizer(PZSummarizer):
         for s, e, test_data, mask in iterator:
             print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
             self._process_chunk(
-                s, e, test_data, mask, first, bootstrap_matrix, single_hist, hist_vals
+                s, e, test_data, mask, first, single_hist, hist_vals
             )
             first = False
             del test_data
@@ -97,20 +96,19 @@ class PointEstHistSummarizer(PZSummarizer):
         test_data: qp.Ensemble,
         mask: np.ndarray,
         _first: bool,
-        bootstrap_matrix: np.ndarray,
         single_hist: np.ndarray,
         hist_vals: np.ndarray,
     ) -> None:
         assert self.zgrid is not None
         zb = test_data.ancil[self.config.point_estimate_key]
         single_hist += np.histogram(zb[mask], bins=self.zgrid)[0]
+        # get a new random seed for each chunk, but make it deterministic
+        # by using the chunk start index and the base seed together
+        rng = np.random.default_rng(seed=[self.config.seed, start])
         for i in range(self.config.n_samples):
-            bootstrap_indeces = bootstrap_matrix[:, i]
-            # Neither all of the bootstrap_draws are in this chunk nor the index starts at "start"
-            chunk_mask = (bootstrap_indeces >= start) & (bootstrap_indeces < end)
-            bootstrap_indeces = bootstrap_indeces[chunk_mask] - start
-            zarr = np.where(mask, zb, np.nan)[bootstrap_indeces]
-            hist_vals[i] += np.histogram(zarr, bins=self.zgrid)[0]
+            # poisson bootstrap
+            bootstrap_weights = rng.poisson(lam=1.0, size=zb.size)
+            hist_vals[i] += np.histogram(zb, weights=bootstrap_weights, bins=self.zgrid)[0]
 
 
 class PointEstHistMaskedSummarizer(PointEstHistSummarizer):

--- a/src/rail/estimation/summarizer.py
+++ b/src/rail/estimation/summarizer.py
@@ -115,21 +115,6 @@ class PZSummarizer(RailStage):
 
         # return self.get_handle("output")
 
-    def _broadcast_bootstrap_matrix(self) -> np.ndarray | None:
-        rng = np.random.default_rng(seed=self.config.seed)
-        # Only one of the nodes needs to produce the bootstrap indices
-        ngal = self._input_length
-        if self.rank == 0:
-            bootstrap_matrix = rng.integers(
-                low=0, high=ngal, size=(ngal, self.config.n_samples)
-            )
-        else:  # pragma: no cover
-            bootstrap_matrix = None
-        if self.comm is not None:  # pragma: no cover
-            self.comm.Barrier()
-            bootstrap_matrix = self.comm.bcast(bootstrap_matrix, root=0)
-        return bootstrap_matrix
-
     def _join_histograms(
         self, bvals: np.ndarray, yvals: np.ndarray
     ) -> tuple[np.ndarray, np.ndarray]:  # pragma: no cover


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Addresses issue #259 by replacing the bootstrapping approach with [Poisson bootstrap](https://en.wikipedia.org/wiki/Bootstrapping_(statistics)#Poisson_bootstrap) which does not require communication or anything stored and shared between processes.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
