### PR TITLE
Add gc.collect() calls to avoid memory issues somewhere

### DIFF
--- a/src/rail/estimation/algos/naive_stack.py
+++ b/src/rail/estimation/algos/naive_stack.py
@@ -7,6 +7,7 @@ from typing import Any, Generator
 import numpy as np
 import qp
 from ceci.config import StageParameter as Param
+import gc
 
 from rail.core.data import QPHandle, TableHandle, TableLike
 from rail.core.common_params import SharedParams, TOMOGRAPHY_ALL, TOMOGRAPHY_NONE
@@ -100,6 +101,7 @@ class NaiveStackSummarizer(PZSummarizer):
             self._process_chunk(
                 s, e, test_data, mask, first, bootstrap_matrix, yvals, bvals
             )
+            gc.collect()
             first = False
         if self.comm is not None:  # pragma: no cover
             bvals, yvals = self._join_histograms(bvals, yvals)

--- a/src/rail/estimation/algos/point_est_hist.py
+++ b/src/rail/estimation/algos/point_est_hist.py
@@ -7,6 +7,7 @@ from typing import Any, Generator
 import numpy as np
 import qp
 from ceci.config import StageParameter as Param
+import gc
 
 from rail.core.data import QPHandle, TableHandle, TableLike
 from rail.core.common_params import SharedParams, TOMOGRAPHY_ALL, TOMOGRAPHY_NONE
@@ -76,6 +77,7 @@ class PointEstHistSummarizer(PZSummarizer):
                 s, e, test_data, mask, first, bootstrap_matrix, single_hist, hist_vals
             )
             first = False
+            gc.collect()
             del test_data
         if self.comm is not None:  # pragma: no cover
             hist_vals, single_hist = self._join_histograms(hist_vals, single_hist)

--- a/src/rail/estimation/algos/true_nz.py
+++ b/src/rail/estimation/algos/true_nz.py
@@ -7,6 +7,7 @@ from typing import Any, Generator
 import numpy as np
 import qp
 from ceci.config import StageParameter as Param
+import gc
 
 from rail.core.common_params import SHARED_PARAMS, SharedParams
 from rail.core.data import PqHandle, QPHandle, TableHandle, TableLike
@@ -75,6 +76,7 @@ class TrueNZHistogrammer(RailStage):
         for s, e, data, mask in iterator:
             print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
             self._process_chunk(s, e, data, mask, first, single_hist)
+            gc.collect()
             first = False
         if self.comm is not None:  # pragma: no cover
             single_hist = self.comm.reduce(single_hist)

--- a/src/rail/estimation/algos/var_inf.py
+++ b/src/rail/estimation/algos/var_inf.py
@@ -9,6 +9,7 @@ import qp
 from ceci.config import StageParameter as Param
 from scipy.special import digamma
 from scipy.stats import dirichlet
+import gc
 
 from rail.core.data import QPHandle
 from rail.core.common_params import SharedParams
@@ -111,6 +112,7 @@ class VarInfStackSummarizer(PZSummarizer):
         for s, e, test_data in iterator:
             print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
             alpha_trace = self._process_chunk(s, e, test_data, first)
+            gc.collect()
             first = False
 
         if self.rank == 0:

--- a/src/rail/estimation/informer.py
+++ b/src/rail/estimation/informer.py
@@ -11,6 +11,7 @@ from typing import Any, Generator
 import numpy as np
 import qp
 import tables_io
+import gc
 
 from rail.core.common_params import SHARED_PARAMS, SharedParams
 from rail.core.data import DataHandle, ModelHandle, QPHandle, TableHandle, TableLike
@@ -208,6 +209,7 @@ class PzInformer(RailStage):
             print(f"Process {self.rank} running estimator on chunk {s:,} - {e:,}")
             self._process_chunk(s, e, test_data, truth_data, first)
             first = False
+            gc.collect()
         self._finalize_run()
 
     def _initialize_run(self) -> None:


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

Running the point estimate summation class at NERSC I experienced out-of-memory crashes when running on large catalogs, even though the algorithm inherently should not store any growing information. I found that adding garbage collection calls fixed this. I assume that somewhere in the underlying qp or tables_io loading something is preventing GC running automatically. This just adds a set of gc calls to various places after `_process_chunk` calls.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
